### PR TITLE
small tweaks to documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,17 @@
+---
+name: Documentation Request
+about: Inform of documentation gaps
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the request**
+A clear and concise description of what the problem is. Ex. It's always hard to find documentation about interaction effects [...]
+
+**Describe the severity of the documentation/testing gap**
+Documentation does not exist, documentation is unclear, documentation is incomplete, lack of documentation requires going to a maintainer, etc.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/deploy-codeartifact-cloudfront.yml
+++ b/.github/workflows/deploy-codeartifact-cloudfront.yml
@@ -59,7 +59,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id=$CloudFrontDistributionId --paths "/*"
 
       - name: Authenticate to codeartifact 
-        run: aws codeartifact login --tool npm --repository shared-package-repository --domain shared-package-domain --namespace @web-ast
+        run: aws codeartifact login --tool npm --repository shared-package-repository --domain shared-package-domain --namespace @hsi
 
       - name: Deploy to codeartifact
         run: | 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+[0.0.71](https://github.com/mathematica-org/viz-components/releases/tag/0.0.71) 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
 # VizComponents
 
+VizComponents is a library of Angular components built on top of D3 that can be composed by a user to create custom visualizations.
+
+VizComponents takes care of common data viz functionality under the hood, such as setting scales, creating axes, and responsively scaling svgs. At the same time Viz Components allows the user to fully customize the system of visual marks used to represent data.
+
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 14.0.0.
 
-# Documentation
+## How to use
 
-(these links only work on documentation server)
+1.  set your aws credentials (found in `~/.aws/credentials`)
+2.  `aws codeartifact login --tool npm --domain shared-package-domain --repository shared-package-repository --domain-owner 922539530544 --namespace @hsi`
+3. `npm i @hsi/[PACKAGE_NAME_HERE]`
+4. Once the package is installed, you can use it like any normal third party package
 
-[bars](http://127.0.0.1:8080/components/BarsComponent.html)
+## Example Projects
 
-## Development server
+- [Covid Cohort](https://github.com/mathematica-org/covid-cohort)
+- [Scorecard](https://github.com/mathematica-org/MACScorecard-Frontend)
+Uses VizComponents bars, lines, and geographies. Uses image and data download services. Examples of custom/extended bars, lines, and geographies components. Geography is US map, and has small state squares w/hover & click effects. 
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+## Feedback, Bugs, and Issues
 
-## Code scaffolding
+Please submit any feedback, bugs, or issues to the repository's issue tracker. This keeps everything in one location, rather than having Jira tickets scattered across different projects.  You're welcome to create jira tickets in external projects to track as well, but there should be a Github Issue to track any work that needs to be done in this repository.
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+See the Contributing section for more information.
 
-## Build
+## Maintainers
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Maintainers of this package can help integrate this shared package into a project, triage bugs, and review pull requests. To become a maintainer, you need to have contributed at least five pull requests to the shared package and demonstrate an overall understanding of the architecture used. (We want more maintainers!) 
 
-## Documentation
+Maintainers are jointly responsible for reviewing issue requests and PRs in a timely manner.
 
-To generate documentation, run `npm run compodoc:build-and-serve`. This also watches for file changes and will rebuild when necessary.
+Our current maintainers are: 
 
-## Running unit tests
+- Stephanie Tuerk
+- Ellie Irish
+- Claire McShane
+- Tom Coile
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+[See more on the role of maintainers here.](https://mathematicampr.atlassian.net/wiki/spaces/WEB/pages/2519892380/Shared+Package+Maintenance+and+Development)
 
-## Running end-to-end tests
+## Contributing
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+1. Any github issue that is created needs to be approved by at least three maintainers before development work starts AND the github issue needs to be published to our [slack channel](https://astwebcloud.slack.com/archives/C06865ECFFE). Approval includes: 
+  - Maintainers agree that the bug/feature is a good fit for the shared package
+  - Maintainers & issue opener have a code design plan of proposed changes - this is documented both in the initial issue and in the conversation following, and should describe any functions' / configs' input/output changes, planned testing, etc. 
 
-## Further help
+2. Once a github issue is approved for development, open a PR, and link again in our package's [slack channel](https://astwebcloud.slack.com/archives/C06865ECFFE).
+3. Two maintainers need to review the PR for it to be merged. 
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+## Development Best Practices
+
+TODO: add some info about best practices
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a full list of changes. We only record minor and major versions in the changelog. 
+
+This document should include a list of each version, and link to the release/tag describing its changes.

--- a/buildspecs/package-release.yml
+++ b/buildspecs/package-release.yml
@@ -13,7 +13,7 @@ phases:
   pre_build: 
     commands: 
       - echo setting up npm with codeartifact
-      - aws codeartifact login --tool npm --repository shared-package-repository --domain shared-package-domain --namespace @web-ast
+      - aws codeartifact login --tool npm --repository shared-package-repository --domain shared-package-domain --namespace @hsi
 
   build: 
     on-failure: ABORT

--- a/projects/demo-app/src/Overview.md
+++ b/projects/demo-app/src/Overview.md
@@ -41,9 +41,9 @@ The library provides minimal default styles for all components in the library, f
 ### Installation
 
 1.  set your aws credentials (found in `~/.aws/credentials`)
-2.  `aws codeartifact login --tool npm --domain shared-package-domain --repository shared-package-repository --domain-owner 922539530544 --namespace @web-ast`
-3.  `npm install @web-ast/viz-components`
+2.  `aws codeartifact login --tool npm --domain shared-package-domain --repository shared-package-repository --domain-owner 922539530544 --namespace @hsi`
+3.  `npm install @hsi/viz-components`
 
 ### Advanced usage: Extending the library in a project-specific way 
 
-We've semi-helpfully created some custom schematics that will set you up with a component that extends whatever viz-components internal thing you care about. Run `ng g @web-ast/viz-components:extend` and follow the instructions from there.
+We've semi-helpfully created some custom schematics that will set you up with a component that extends whatever viz-components internal thing you care about. Run `ng g @hsi/viz-components:extend` and follow the instructions from there.

--- a/projects/viz-components/README.md
+++ b/projects/viz-components/README.md
@@ -27,7 +27,7 @@ Run `./build.sh` to build the project. The build artifacts will be stored in the
         "preinstall": "npm run codeartifact:login",
         "codeartifact:login": "aws codeartifact login --tool npm --repository vizcolib --domain frontend"
 
-2.  run `npm install @web-ast/viz-components`. If it can't be found, it's probably because the preinstall script didn't actually run (it's supposed to but doesn't always, at least not for me, and haven't successfully debugged yet). Manually run the preinstall script, `npm run preinstall`, then run `npm install @web-ast/viz-components` again.
+2.  run `npm install @hsi/viz-components`. If it can't be found, it's probably because the preinstall script didn't actually run (it's supposed to but doesn't always, at least not for me, and haven't successfully debugged yet). Manually run the preinstall script, `npm run preinstall`, then run `npm install @hsi/viz-components` again.
 
 ## Extending a component
 

--- a/projects/viz-components/code-snippets/code_snippet_generator.py
+++ b/projects/viz-components/code-snippets/code_snippet_generator.py
@@ -17,7 +17,7 @@ def runner(event, context):
 
 def load_files():
     fileList = []
-    for root, dirs, files in os.walk('../src/lib'):
+    for root, dirs, files in os.walk("../src/lib"):
         for file in files:
             if file.endswith(".config.ts"):
                 fileName = os.path.join(root, file).replace("\\", "/")
@@ -32,7 +32,7 @@ def create_configs(fileList):
         openedFile = open(file)
         lines = openedFile.readlines()
         configs = merge(configs, generate_configs_from_lines(lines))
-    while(some_configs_unprocessed(configs)):
+    while some_configs_unprocessed(configs):
         parse_configs(configs)
     return configs
 
@@ -41,10 +41,13 @@ def create_code_snippets_from_configs(configs):
     finalJson = {}
     for config in configs:
         currentConfig = configs[config]
-        finalJson[f'Full{currentConfig.name}'] = generate_single_code_snippet(
-            currentConfig)
+        finalJson[f"Vic{currentConfig.name}"] = generate_single_code_snippet(
+            currentConfig
+        )
 
-    with open('../../../.vscode/vizcolib-configs.code-snippets', 'w', encoding='utf-8') as file:
+    with open(
+        "../../../.vscode/vizcolib-configs.code-snippets", "w", encoding="utf-8"
+    ) as file:
         json.dump(finalJson, file, ensure_ascii=False, indent=4)
 
 

--- a/projects/viz-components/package.json
+++ b/projects/viz-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@web-ast/viz-components",
+  "name": "@hsi/viz-components",
   "version": "0.0.71",
   "scripts": {
     "build": "tsc -p tsconfig.schematics.json",

--- a/projects/viz-components/schematics/extend/files/__name@dasherize__.component.ts.template
+++ b/projects/viz-components/schematics/extend/files/__name@dasherize__.component.ts.template
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { <%= classify(extend) %>Component } from '@web-ast/viz-components'
+import { <%= classify(extend) %>Component } from '@hsi/viz-components'
 
 @Component({
   selector: 'app-<%= dasherize(name) %>',

--- a/projects/viz-components/src/lib/axes/x-ordinal/x-ordinal-axis.component.ts
+++ b/projects/viz-components/src/lib/axes/x-ordinal/x-ordinal-axis.component.ts
@@ -18,7 +18,7 @@ const XOrdinalAxis = mixinXAxis(OrdinalAxisMixin(XyAxis));
  *
  * <p class="comment-example">Example usage</p>
  *
- * import { VicXOrdinalAxisModule } from '@web-ast/viz-components';
+ * import { VicXOrdinalAxisModule } from '@hsi/viz-components';
  *
  * imports: [VicXOrdinalAxisModule]
  *

--- a/projects/viz-components/src/lib/axes/x-quantitative/x-quantitative-axis.component.ts
+++ b/projects/viz-components/src/lib/axes/x-quantitative/x-quantitative-axis.component.ts
@@ -18,7 +18,7 @@ const XQuantitativeAxis = mixinXAxis(mixinQuantitativeAxis(XyAxis));
  *
  * <p class="comment-example">Example usage</p>
  *
- * import { VicXQuantitativeAxisModule } from '@web-ast/viz-components';
+ * import { VicXQuantitativeAxisModule } from '@hsi/viz-components';
  *
  * imports: [VicXQuantitativeAxisModule]
  *

--- a/projects/viz-components/src/lib/axes/y-ordinal/y-ordinal-axis.component.ts
+++ b/projects/viz-components/src/lib/axes/y-ordinal/y-ordinal-axis.component.ts
@@ -18,7 +18,7 @@ const YOrdinalAxis = mixinYAxis(OrdinalAxisMixin(XyAxis));
  *
  * <p class="comment-example">Example usage</p>
  *
- * import { VicYOrdinalAxisModule } from '@web-ast/viz-components';
+ * import { VicYOrdinalAxisModule } from '@hsi/viz-components';
  *
  * imports: [VicYOrdinalAxisModule]
  *

--- a/projects/viz-components/src/lib/axes/y-quantitative-axis/y-quantitative-axis.component.ts
+++ b/projects/viz-components/src/lib/axes/y-quantitative-axis/y-quantitative-axis.component.ts
@@ -18,7 +18,7 @@ const YQuantitativeAxis = mixinYAxis(mixinQuantitativeAxis(XyAxis));
  *
  * <p class="comment-example">Example usage</p>
  *
- * import { VicYQuantitativeAxisModule } from '@web-ast/viz-components';
+ * import { VicYQuantitativeAxisModule } from '@hsi/viz-components';
  *
  * imports: [VicYQuantitativeAxisModule]
  *


### PR DESCRIPTION
Resolves #161, resolves #137 

@stephanietuerk the only breaking change in this PR is changing `@web-ast` prefix to `@hsi` instead - so future versions of viz-components will need to be installed with `@hsi`. Old versions still exist under the `@web-ast` prefix, so this doesn't break anything.