### PR TITLE
rename configs, enums to be prefaced with Vic

### DIFF
--- a/projects/demo-app/src/app/bars-example/bars-example.component.ts
+++ b/projects/demo-app/src/app/bars-example/bars-example.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { format } from 'd3';
-import { AxisConfig } from 'projects/viz-components/src/lib/axes/axis.config';
+import { VicAxisConfig } from 'projects/viz-components/src/lib/axes/axis.config';
 import { BarsHoverShowLabels } from 'projects/viz-components/src/lib/bars/bars-hover-effects';
 import { BarsHoverMoveDirective } from 'projects/viz-components/src/lib/bars/bars-hover-move.directive';
 import { BarsHoverDirective } from 'projects/viz-components/src/lib/bars/bars-hover.directive';
-import { BarsEventOutput } from 'projects/viz-components/src/lib/bars/bars-tooltip-data';
+import { VicBarsEventOutput } from 'projects/viz-components/src/lib/bars/bars-tooltip-data';
 import {
-  BarsConfig,
-  BarsLabelsConfig,
-  HorizontalBarsDimensionsConfig,
+  VicBarsConfig,
+  VicBarsLabelsConfig,
+  VicHorizontalBarsDimensionsConfig,
 } from 'projects/viz-components/src/lib/bars/bars.config';
 import { ElementSpacing } from 'projects/viz-components/src/lib/chart/chart.component';
 import {
@@ -16,25 +16,25 @@ import {
   HoverMoveEventEffect,
 } from 'projects/viz-components/src/lib/events/effect';
 import {
-  HtmlTooltipConfig,
-  HtmlTooltipOffsetFromOriginPosition,
+  VicHtmlTooltipConfig,
+  VicHtmlTooltipOffsetFromOriginPosition,
 } from 'projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.config';
 import {
   BarsHoverMoveEmitTooltipData,
-  PixelDomainPaddingConfig,
+  VicPixelDomainPaddingConfig,
 } from 'projects/viz-components/src/public-api';
 import { BehaviorSubject, filter, map, Observable } from 'rxjs';
 import { MetroUnemploymentDatum } from '../core/models/data';
 import { DataService } from '../core/services/data.service';
 
 interface ViewModel {
-  dataConfig: BarsConfig;
-  xAxisConfig: AxisConfig;
-  yAxisConfig: AxisConfig;
+  dataConfig: VicBarsConfig;
+  xAxisConfig: VicAxisConfig;
+  yAxisConfig: VicAxisConfig;
 }
 
-class BarsExampleTooltipConfig extends HtmlTooltipConfig {
-  constructor(config: Partial<HtmlTooltipConfig> = {}) {
+class BarsExampleTooltipConfig extends VicHtmlTooltipConfig {
+  constructor(config: Partial<VicHtmlTooltipConfig> = {}) {
     super();
     this.size.minWidth = 130;
     Object.assign(this, config);
@@ -55,13 +55,13 @@ export class BarsExampleComponent implements OnInit {
     left: 300,
   };
   folderName = 'bars-example';
-  tooltipConfig: BehaviorSubject<HtmlTooltipConfig> =
-    new BehaviorSubject<HtmlTooltipConfig>(
-      new HtmlTooltipConfig(new BarsExampleTooltipConfig())
+  tooltipConfig: BehaviorSubject<VicHtmlTooltipConfig> =
+    new BehaviorSubject<VicHtmlTooltipConfig>(
+      new VicHtmlTooltipConfig(new BarsExampleTooltipConfig())
     );
   tooltipConfig$ = this.tooltipConfig.asObservable();
-  tooltipData: BehaviorSubject<BarsEventOutput> =
-    new BehaviorSubject<BarsEventOutput>(null);
+  tooltipData: BehaviorSubject<VicBarsEventOutput> =
+    new BehaviorSubject<VicBarsEventOutput>(null);
   tooltipData$ = this.tooltipData.asObservable();
   hoverAndMoveEffects: HoverMoveEventEffect<BarsHoverMoveDirective>[] = [
     new BarsHoverMoveEmitTooltipData(),
@@ -81,11 +81,11 @@ export class BarsExampleComponent implements OnInit {
     const filteredData = data.filter(
       (d) => d.date.getFullYear() === 2008 && d.date.getMonth() === 3
     );
-    const xAxisConfig = new AxisConfig();
+    const xAxisConfig = new VicAxisConfig();
     xAxisConfig.tickFormat = '.0f';
-    const yAxisConfig = new AxisConfig();
-    const dataConfig = new BarsConfig();
-    dataConfig.labels = new BarsLabelsConfig();
+    const yAxisConfig = new VicAxisConfig();
+    const dataConfig = new VicBarsConfig();
+    dataConfig.labels = new VicBarsLabelsConfig();
     dataConfig.labels.display = false;
     dataConfig.quantitative.valueFormat = (d: any) => {
       const label =
@@ -95,10 +95,10 @@ export class BarsExampleComponent implements OnInit {
       return d.value > 8 ? `${label}*` : label;
     };
     dataConfig.data = filteredData;
-    dataConfig.dimensions = new HorizontalBarsDimensionsConfig();
+    dataConfig.dimensions = new VicHorizontalBarsDimensionsConfig();
     dataConfig.ordinal.valueAccessor = (d) => d.division;
     dataConfig.quantitative.valueAccessor = (d) => d.value;
-    dataConfig.quantitative.domainPadding = new PixelDomainPaddingConfig();
+    dataConfig.quantitative.domainPadding = new VicPixelDomainPaddingConfig();
     return {
       dataConfig,
       xAxisConfig,
@@ -106,18 +106,18 @@ export class BarsExampleComponent implements OnInit {
     };
   }
 
-  updateTooltipForNewOutput(data: BarsEventOutput): void {
+  updateTooltipForNewOutput(data: VicBarsEventOutput): void {
     this.updateTooltipData(data);
     this.updateTooltipConfig(data);
   }
 
-  updateTooltipData(data: BarsEventOutput): void {
+  updateTooltipData(data: VicBarsEventOutput): void {
     this.tooltipData.next(data);
   }
 
-  updateTooltipConfig(data: BarsEventOutput): void {
+  updateTooltipConfig(data: VicBarsEventOutput): void {
     const config = new BarsExampleTooltipConfig();
-    config.position = new HtmlTooltipOffsetFromOriginPosition();
+    config.position = new VicHtmlTooltipOffsetFromOriginPosition();
     if (data) {
       config.position.offsetX = data.positionX;
       config.position.offsetY = data.positionY;

--- a/projects/demo-app/src/app/core/services/basemap.service.ts
+++ b/projects/demo-app/src/app/core/services/basemap.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FeatureCollection } from 'geojson';
-import { NoDataGeographyConfig } from 'projects/viz-components/src/public-api';
+import { VicNoDataGeographyConfig } from 'projects/viz-components/src/public-api';
 import { Observable, shareReplay } from 'rxjs';
 import * as topojson from 'topojson-client';
 import { Topology } from 'topojson-specification';
@@ -14,7 +14,7 @@ export class BasemapService {
   map$: Observable<Topology>;
   us: FeatureCollection;
   states: FeatureCollection;
-  usOutlineConfig: NoDataGeographyConfig;
+  usOutlineConfig: VicNoDataGeographyConfig;
 
   constructor(private data: DataResource) {}
 
@@ -46,7 +46,7 @@ export class BasemapService {
   }
 
   private setUsOutlineConfig(): void {
-    const outlineGeography = new NoDataGeographyConfig();
+    const outlineGeography = new VicNoDataGeographyConfig();
     outlineGeography.geographies = this.us.features;
     outlineGeography.strokeWidth = '1';
     outlineGeography.strokeColor = colors.base;

--- a/projects/demo-app/src/app/geographies-example/geographies-example.component.ts
+++ b/projects/demo-app/src/app/geographies-example/geographies-example.component.ts
@@ -3,20 +3,20 @@ import { MatButtonToggleChange } from '@angular/material/button-toggle';
 import { EventEffect } from 'projects/viz-components/src/lib/events/effect';
 import { GeographiesHoverDirective } from 'projects/viz-components/src/lib/geographies/geographies-hover.directive';
 import {
-  HtmlTooltipConfig,
-  HtmlTooltipOffsetFromOriginPosition,
+  VicHtmlTooltipConfig,
+  VicHtmlTooltipOffsetFromOriginPosition,
 } from 'projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.config';
 import { valueFormat } from 'projects/viz-components/src/lib/value-format/value-format';
 import {
-  DataGeographyConfig,
+  VicDataGeographyConfig,
   ElementSpacing,
-  EqualValuesQuantitativeAttributeDataDimensionConfig,
+  VicEqualValuesQuantitativeAttributeDataDimensionConfig,
   GeographiesClickDirective,
   GeographiesClickEmitTooltipDataPauseHoverMoveEffects,
-  GeographiesConfig,
-  GeographiesEventOutput,
+  VicGeographiesConfig,
+  VicGeographiesEventOutput,
   GeographiesHoverEmitTooltipData,
-  NoDataGeographyConfig,
+  VicNoDataGeographyConfig,
 } from 'projects/viz-components/src/public-api';
 import {
   BehaviorSubject,
@@ -55,18 +55,18 @@ export class GeographiesExampleComponent implements OnInit {
     'custom breaks',
     'categorical',
   ];
-  dataMarksConfig$: Observable<GeographiesConfig>;
+  dataMarksConfig$: Observable<VicGeographiesConfig>;
   width = 700;
   height = 400;
   margin: ElementSpacing = { top: 0, right: 0, bottom: 0, left: 0 };
   outlineColor = colors.base;
-  tooltipConfig: BehaviorSubject<HtmlTooltipConfig> =
-    new BehaviorSubject<HtmlTooltipConfig>(
-      new HtmlTooltipConfig({ show: false })
+  tooltipConfig: BehaviorSubject<VicHtmlTooltipConfig> =
+    new BehaviorSubject<VicHtmlTooltipConfig>(
+      new VicHtmlTooltipConfig({ show: false })
     );
   tooltipConfig$ = this.tooltipConfig.asObservable();
-  tooltipData: BehaviorSubject<GeographiesEventOutput> =
-    new BehaviorSubject<GeographiesEventOutput>(null);
+  tooltipData: BehaviorSubject<VicGeographiesEventOutput> =
+    new BehaviorSubject<VicGeographiesEventOutput>(null);
   tooltipData$ = this.tooltipData.asObservable();
   hoverEffects: EventEffect<GeographiesHoverDirective>[] = [
     new GeographiesHoverEmitTooltipData(),
@@ -109,8 +109,8 @@ export class GeographiesExampleComponent implements OnInit {
   getDataMarksConfig(
     data: StateIncomeDatum[],
     map: Topology
-  ): GeographiesConfig {
-    const config = new GeographiesConfig();
+  ): VicGeographiesConfig {
+    const config = new VicGeographiesConfig();
     config.data = data;
     config.boundary = this.basemap.us;
     const noDataStatesConfig = this.getNoDataGeographyStatesFeatures(map, data);
@@ -125,12 +125,12 @@ export class GeographiesExampleComponent implements OnInit {
   getDataGeographyConfig(
     map: Topology,
     data: StateIncomeDatum[]
-  ): DataGeographyConfig {
-    const config = new DataGeographyConfig();
+  ): VicDataGeographyConfig {
+    const config = new VicDataGeographyConfig();
     config.geographies = this.getDataGeographyFeatures(map, data);
     config.valueAccessor = (d) => d.properties['name'];
     config.attributeDataConfig =
-      new EqualValuesQuantitativeAttributeDataDimensionConfig();
+      new VicEqualValuesQuantitativeAttributeDataDimensionConfig();
     config.attributeDataConfig.geoAccessor = (d) => d.state;
     config.attributeDataConfig.valueAccessor = (d) => d.income;
     config.attributeDataConfig.valueFormat = `$${valueFormat.integer}`;
@@ -151,12 +151,12 @@ export class GeographiesExampleComponent implements OnInit {
   getNoDataGeographyStatesFeatures(
     map: Topology,
     data: StateIncomeDatum[]
-  ): NoDataGeographyConfig {
+  ): VicNoDataGeographyConfig {
     const statesInData = data.map((x) => x.state);
     const features = topojson
       .feature(map, map.objects['states'])
       ['features'].filter((x) => !statesInData.includes(x.properties.name));
-    return new NoDataGeographyConfig({
+    return new VicNoDataGeographyConfig({
       geographies: features,
       patternName: this.patternName,
     });
@@ -170,26 +170,26 @@ export class GeographiesExampleComponent implements OnInit {
   }
 
   updateTooltipForNewOutput(
-    data: GeographiesEventOutput,
+    data: VicGeographiesEventOutput,
     tooltipEvent: 'hover' | 'click'
   ): void {
     this.updateTooltipData(data);
     this.updateTooltipConfig(data, tooltipEvent);
   }
 
-  updateTooltipData(data: GeographiesEventOutput): void {
+  updateTooltipData(data: VicGeographiesEventOutput): void {
     this.tooltipData.next(data);
   }
 
   updateTooltipConfig(
-    data: GeographiesEventOutput,
+    data: VicGeographiesEventOutput,
     eventContext: 'hover' | 'click'
   ): void {
-    const config = new HtmlTooltipConfig();
+    const config = new VicHtmlTooltipConfig();
     config.size.minWidth = 130;
     config.hasBackdrop = eventContext === 'click';
     config.closeOnBackdropClick = eventContext === 'click';
-    config.position = new HtmlTooltipOffsetFromOriginPosition();
+    config.position = new VicHtmlTooltipOffsetFromOriginPosition();
     if (data) {
       config.position.offsetX = data.positionX;
       config.position.offsetY = data.positionY;

--- a/projects/demo-app/src/app/lines-example/lines-example.component.ts
+++ b/projects/demo-app/src/app/lines-example/lines-example.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
-import { AxisConfig } from 'projects/viz-components/src/lib/axes/axis.config';
+import { VicAxisConfig } from 'projects/viz-components/src/lib/axes/axis.config';
 import { ElementSpacing } from 'projects/viz-components/src/lib/chart/chart.component';
 import {
   EventEffect,
@@ -24,32 +24,32 @@ import {
 } from 'projects/viz-components/src/lib/lines/lines-hover-move-effects';
 
 import {
-  ColumnConfig,
-  DataExportConfig,
+  VicColumnConfig,
+  VicDataExportConfig,
 } from 'projects/viz-components/src/lib/export-data/data-export.config';
 import { LinesHoverMoveDirective } from 'projects/viz-components/src/lib/lines/lines-hover-move.directive';
-import { LinesEventOutput } from 'projects/viz-components/src/lib/lines/lines-tooltip-data';
-import { LinesConfig } from 'projects/viz-components/src/lib/lines/lines.config';
+import { VicLinesEventOutput } from 'projects/viz-components/src/lib/lines/lines-tooltip-data';
+import { VicLinesConfig } from 'projects/viz-components/src/lib/lines/lines.config';
 import {
-  HtmlTooltipConfig,
-  HtmlTooltipOffsetFromOriginPosition,
+  VicHtmlTooltipConfig,
+  VicHtmlTooltipOffsetFromOriginPosition,
 } from 'projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.config';
-import { PixelDomainPaddingConfig } from 'projects/viz-components/src/public-api';
+import { VicPixelDomainPaddingConfig } from 'projects/viz-components/src/public-api';
 import { BehaviorSubject, filter, map, Observable, Subject } from 'rxjs';
 import { MetroUnemploymentDatum } from '../core/models/data';
 import { DataService } from '../core/services/data.service';
 import { HighlightLineForLabel } from './line-input-effects';
 
 interface ViewModel {
-  dataConfig: LinesConfig;
-  xAxisConfig: AxisConfig;
-  yAxisConfig: AxisConfig;
+  dataConfig: VicLinesConfig;
+  xAxisConfig: VicAxisConfig;
+  yAxisConfig: VicAxisConfig;
   labels: string[];
 }
 const includeFiles = ['line-input-effects.ts'];
 
-class LinesExampleTooltipConfig extends HtmlTooltipConfig {
-  constructor(config: Partial<HtmlTooltipConfig> = {}) {
+class LinesExampleTooltipConfig extends VicHtmlTooltipConfig {
+  constructor(config: Partial<VicHtmlTooltipConfig> = {}) {
     super();
     this.size.minWidth = 340;
     Object.assign(this, config);
@@ -70,13 +70,13 @@ export class LinesExampleComponent implements OnInit {
     bottom: 36,
     left: 64,
   };
-  tooltipConfig: BehaviorSubject<HtmlTooltipConfig> =
-    new BehaviorSubject<HtmlTooltipConfig>(
+  tooltipConfig: BehaviorSubject<VicHtmlTooltipConfig> =
+    new BehaviorSubject<VicHtmlTooltipConfig>(
       new LinesExampleTooltipConfig({ show: false })
     );
   tooltipConfig$ = this.tooltipConfig.asObservable();
-  tooltipData: BehaviorSubject<LinesEventOutput> =
-    new BehaviorSubject<LinesEventOutput>(null);
+  tooltipData: BehaviorSubject<VicLinesEventOutput> =
+    new BehaviorSubject<VicLinesEventOutput>(null);
   tooltipData$ = this.tooltipData.asObservable();
   chartInputEvent: BehaviorSubject<string> = new BehaviorSubject<string>(null);
   chartInputEvent$ = this.chartInputEvent.asObservable();
@@ -119,10 +119,10 @@ export class LinesExampleComponent implements OnInit {
   }
 
   getViewModel(data: MetroUnemploymentDatum[]): ViewModel {
-    const xAxisConfig = new AxisConfig();
+    const xAxisConfig = new VicAxisConfig();
     xAxisConfig.tickFormat = '%Y';
-    const yAxisConfig = new AxisConfig();
-    const dataConfig = new LinesConfig();
+    const yAxisConfig = new VicAxisConfig();
+    const dataConfig = new VicLinesConfig();
     dataConfig.data = data;
     dataConfig.x.valueAccessor = (d) => d.date;
     dataConfig.x.valueFormat = '%a %B %d %Y';
@@ -130,7 +130,7 @@ export class LinesExampleComponent implements OnInit {
     dataConfig.category.valueAccessor = (d) => d.division;
     dataConfig.pointMarkers.radius = 2;
     const labels = [...new Set(data.map((x) => x.division))].slice(0, 9);
-    dataConfig.y.domainPadding = new PixelDomainPaddingConfig();
+    dataConfig.y.domainPadding = new VicPixelDomainPaddingConfig();
     return {
       dataConfig,
       xAxisConfig,
@@ -140,25 +140,25 @@ export class LinesExampleComponent implements OnInit {
   }
 
   updateTooltipForNewOutput(
-    data: LinesEventOutput,
+    data: VicLinesEventOutput,
     tooltipEvent: 'hover' | 'click'
   ): void {
     this.updateTooltipData(data);
     this.updateTooltipConfig(data, tooltipEvent);
   }
 
-  updateTooltipData(data: LinesEventOutput): void {
+  updateTooltipData(data: VicLinesEventOutput): void {
     this.tooltipData.next(data);
   }
 
   updateTooltipConfig(
-    data: LinesEventOutput,
+    data: VicLinesEventOutput,
     eventContext: 'click' | 'hover'
   ): void {
     const config = new LinesExampleTooltipConfig();
     config.hasBackdrop = eventContext === 'click';
     config.closeOnBackdropClick = eventContext === 'click';
-    config.position = new HtmlTooltipOffsetFromOriginPosition();
+    config.position = new VicHtmlTooltipOffsetFromOriginPosition();
     if (data) {
       config.position.offsetX = data.positionX;
       config.position.offsetY = data.positionY - 16;
@@ -201,18 +201,18 @@ export class LinesExampleComponent implements OnInit {
       },
     ];
 
-    const dataConfig = new DataExportConfig({
+    const dataConfig = new VicDataExportConfig({
       data: data,
       includeAllKeysAsDefault: true,
     });
-    const lineMetadataConfig = new DataExportConfig({
+    const lineMetadataConfig = new VicDataExportConfig({
       data: lineMetadata,
       flipped: true,
       flippedHeaderKey: 'fileType',
       marginBottom: 2,
       defaultColumnList: ['fileType', 'numFiles'],
       columns: [
-        new ColumnConfig({
+        new VicColumnConfig({
           title: 'Types of Cool ThInGs',
           valueAccessor: (x) => x.typesOfCoolThings,
         }),

--- a/projects/demo-app/src/app/stacked-area-example/stacked-area-example.component.ts
+++ b/projects/demo-app/src/app/stacked-area-example/stacked-area-example.component.ts
@@ -1,17 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import {
-  AxisConfig,
+  VicAxisConfig,
   ElementSpacing,
-  StackedAreaConfig,
+  VicStackedAreaConfig,
 } from 'projects/viz-components/src/public-api';
 import { filter, map, Observable } from 'rxjs';
 import { IndustryUnemploymentDatum } from '../core/models/data';
 import { DataService } from '../core/services/data.service';
 
 interface ViewModel {
-  dataConfig: StackedAreaConfig;
-  xAxisConfig: AxisConfig;
-  yAxisConfig: AxisConfig;
+  dataConfig: VicStackedAreaConfig;
+  xAxisConfig: VicAxisConfig;
+  yAxisConfig: VicAxisConfig;
 }
 
 @Component({
@@ -39,10 +39,10 @@ export class StackedAreaExampleComponent implements OnInit {
   }
 
   getViewModel(data: IndustryUnemploymentDatum[]): ViewModel {
-    const xAxisConfig = new AxisConfig();
+    const xAxisConfig = new VicAxisConfig();
     xAxisConfig.tickFormat = '%Y';
-    const yAxisConfig = new AxisConfig();
-    const dataConfig = new StackedAreaConfig();
+    const yAxisConfig = new VicAxisConfig();
+    const dataConfig = new VicStackedAreaConfig();
     dataConfig.data = data;
     dataConfig.x.valueAccessor = (d) => d.date;
     dataConfig.y.valueAccessor = (d) => d.value;

--- a/projects/viz-components/code-snippets/useCase.ts
+++ b/projects/viz-components/code-snippets/useCase.ts
@@ -1,13 +1,13 @@
 import {
-  AxisConfig,
-  BarsConfig,
-  BarsLabelsConfig,
-  OrdinalDimensionConfig,
-  QuantitativeDimensionConfig,
+  VicAxisConfig,
+  VicBarsConfig,
+  VicBarsLabelsConfig,
+  VicOrdinalDimensionConfig,
+  VicQuantitativeDimensionConfig,
   verticalBarChartDimensionsConfig,
 } from '../src/public-api';
 
-const config = new AxisConfig({
+const config = new VicAxisConfig({
   // numTicks: number | TimeInterval,
   // tickFormat: string,
   // tickValues: any[],
@@ -20,12 +20,12 @@ const config = new AxisConfig({
   // tickLabelFontSize: number,
 });
 
-new BarsConfig({
-  ordinal: new OrdinalDimensionConfig(),
-  quantitative: new QuantitativeDimensionConfig(),
+new VicBarsConfig({
+  ordinal: new VicOrdinalDimensionConfig(),
+  quantitative: new VicQuantitativeDimensionConfig(),
   // category: CategoricalColorDimensionConfig
   dimensions: verticalBarChartDimensionsConfig,
-  labels: new BarsLabelsConfig(),
+  labels: new VicBarsLabelsConfig(),
   // data: any[],
   mixBlendMode: 'normal',
   //ordinal.valueAccessor: (d, i) => i,

--- a/projects/viz-components/src/lib/axes/axis.config.ts
+++ b/projects/viz-components/src/lib/axes/axis.config.ts
@@ -1,7 +1,7 @@
 import { TimeInterval } from 'd3';
-import { TickWrapConfig } from '../svg-text-wrap/tick-wrap.config';
+import { VicTickWrapConfig } from '../svg-text-wrap/tick-wrap.config';
 
-export class AxisConfig {
+export class VicAxisConfig {
   /**
    * Used only on quantitative axes.
    *
@@ -68,7 +68,7 @@ export class AxisConfig {
    *  method.
    *
    * Values will be formatted with either the provided value for
-   *  [tickFormat]{@link AxisConfig.tickFormat} or the default format.
+   *  [tickFormat]{@link VicAxisConfig.tickFormat} or the default format.
    */
   tickValues?: any[];
 
@@ -77,9 +77,9 @@ export class AxisConfig {
    *
    * Note: In `Bars`, bar labels are tick labels.
    */
-  wrap?: TickWrapConfig;
+  wrap?: VicTickWrapConfig;
 
-  constructor(init?: Partial<AxisConfig>) {
+  constructor(init?: Partial<VicAxisConfig>) {
     Object.assign(this, init);
   }
 }

--- a/projects/viz-components/src/lib/axes/xy-axis.ts
+++ b/projects/viz-components/src/lib/axes/xy-axis.ts
@@ -3,9 +3,9 @@ import { select } from 'd3';
 import { Observable, pairwise, takeUntil } from 'rxjs';
 import { Unsubscribe } from '../shared/unsubscribe.class';
 import { svgTextWrap } from '../svg-text-wrap/svg-text-wrap';
-import { SvgTextWrapConfig } from '../svg-text-wrap/svg-wrap.config';
+import { VicSvgTextWrapConfig } from '../svg-text-wrap/svg-wrap.config';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
-import { AxisConfig } from './axis.config';
+import { VicAxisConfig } from './axis.config';
 
 /**
  * A base directive for all axes.
@@ -15,7 +15,7 @@ export abstract class XyAxis extends Unsubscribe implements OnInit {
   /**
    * The configuration for the axis.
    */
-  @Input() config: AxisConfig;
+  @Input() config: VicAxisConfig;
   @ViewChild('axis', { static: true }) axisRef: ElementRef<SVGGElement>;
   axisFunction: any;
   axis: any;
@@ -94,9 +94,9 @@ export abstract class XyAxis extends Unsubscribe implements OnInit {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { wrapWidth, ...properties } = this.config.wrap;
     const config = Object.assign(
-      new SvgTextWrapConfig(),
+      new VicSvgTextWrapConfig(),
       properties
-    ) as SvgTextWrapConfig;
+    ) as VicSvgTextWrapConfig;
     let width: number;
     if (this.config.wrap.wrapWidth === 'bandwidth') {
       width = this.scale.bandwidth();

--- a/projects/viz-components/src/lib/bars/bars-click.directive.ts
+++ b/projects/viz-components/src/lib/bars/bars-click.directive.ts
@@ -18,7 +18,7 @@ import { ListenElement } from '../events/event.directive';
 import { BarsHoverMoveDirective } from './bars-hover-move.directive';
 import { BarsHoverDirective } from './bars-hover.directive';
 import { BarsInputEventDirective } from './bars-input-event.directive';
-import { BarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
+import { VicBarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
 import { BARS, BarsComponent } from './bars.component';
 
 type BarsEventDirective =
@@ -37,7 +37,7 @@ export class BarsClickDirective<
   @Input('vicBarsClickRemoveEvent$')
   override clickRemoveEvent$: Observable<void>;
   @Output('vicBarsClickOutput') eventOutput =
-    new EventEmitter<BarsEventOutput>();
+    new EventEmitter<VicBarsEventOutput>();
   barIndex: number;
   elRef: ElementRef;
   pointerX: number;
@@ -89,7 +89,7 @@ export class BarsClickDirective<
     this.pointerY = undefined;
   }
 
-  getEventOutput(): BarsEventOutput {
+  getEventOutput(): VicBarsEventOutput {
     const data = getBarsTooltipData(this.barIndex, this.elRef, this.bars);
     const extras = {
       positionX: this.pointerX,

--- a/projects/viz-components/src/lib/bars/bars-hover-move.directive.ts
+++ b/projects/viz-components/src/lib/bars/bars-hover-move.directive.ts
@@ -12,7 +12,7 @@ import { select } from 'd3';
 import { filter, takeUntil } from 'rxjs';
 import { HoverMoveEventEffect } from '../events/effect';
 import { HoverMoveDirective } from '../events/hover-move.directive';
-import { BarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
+import { VicBarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
 import { BARS, BarsComponent } from './bars.component';
 
 @Directive({
@@ -24,7 +24,7 @@ export class BarsHoverMoveDirective<
   @Input('vicBarsHoverMoveEffects')
   effects: HoverMoveEventEffect<BarsHoverMoveDirective<T>>[];
   @Output('vicBarsHoverMoveOutput') eventOutput =
-    new EventEmitter<BarsEventOutput>();
+    new EventEmitter<VicBarsEventOutput>();
   barIndex: number;
   elRef: ElementRef;
   pointerX: number;
@@ -79,7 +79,7 @@ export class BarsHoverMoveDirective<
     this.elRef = undefined;
   }
 
-  getEventOutput(): BarsEventOutput {
+  getEventOutput(): VicBarsEventOutput {
     const tooltipData = getBarsTooltipData(
       this.barIndex,
       this.elRef,

--- a/projects/viz-components/src/lib/bars/bars-hover.directive.ts
+++ b/projects/viz-components/src/lib/bars/bars-hover.directive.ts
@@ -12,7 +12,7 @@ import { select } from 'd3';
 import { filter, takeUntil } from 'rxjs';
 import { EventEffect } from '../events/effect';
 import { HoverDirective } from '../events/hover.directive';
-import { BarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
+import { VicBarsEventOutput, getBarsTooltipData } from './bars-tooltip-data';
 import { BARS, BarsComponent } from './bars.component';
 
 @Directive({
@@ -24,7 +24,7 @@ export class BarsHoverDirective<
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('vicBarsHoverEffects') effects: EventEffect<BarsHoverDirective<T>>[];
   @Output('vicBarsHoverOutput') eventOutput =
-    new EventEmitter<BarsEventOutput>();
+    new EventEmitter<VicBarsEventOutput>();
   barIndex: number;
   elRef: ElementRef;
   positionX: number;
@@ -63,7 +63,7 @@ export class BarsHoverDirective<
     }
   }
 
-  getEventOutput(): BarsEventOutput {
+  getEventOutput(): VicBarsEventOutput {
     const tooltipData = getBarsTooltipData(
       this.barIndex,
       this.elRef,

--- a/projects/viz-components/src/lib/bars/bars-tooltip-data.ts
+++ b/projects/viz-components/src/lib/bars/bars-tooltip-data.ts
@@ -2,12 +2,12 @@ import { ElementRef } from '@angular/core';
 import { formatValue } from '../value-format/value-format';
 import { BarsComponent } from './bars.component';
 
-export interface BarsEventOutput extends BarsTooltipOutput {
+export interface VicBarsEventOutput extends VicBarsTooltipOutput {
   positionX: number;
   positionY: number;
 }
 
-export interface BarsTooltipOutput {
+export interface VicBarsTooltipOutput {
   datum: any;
   color: string;
   ordinal: string;
@@ -20,7 +20,7 @@ export function getBarsTooltipData(
   barIndex: number,
   elRef: ElementRef,
   bars: BarsComponent
-): BarsTooltipOutput {
+): VicBarsTooltipOutput {
   const datum = bars.config.data.find(
     (d) =>
       bars.values[bars.config.dimensions.quantitative][barIndex] ===
@@ -29,7 +29,7 @@ export function getBarsTooltipData(
         bars.config.ordinal.valueAccessor(d)
   );
 
-  const tooltipData: BarsTooltipOutput = {
+  const tooltipData: VicBarsTooltipOutput = {
     datum,
     color: bars.getBarColor(barIndex),
     ordinal: bars.config.ordinal.valueAccessor(datum),

--- a/projects/viz-components/src/lib/bars/bars.component.spec.ts
+++ b/projects/viz-components/src/lib/bars/bars.component.spec.ts
@@ -5,7 +5,7 @@ import { UtilitiesService } from '../core/services/utilities.service';
 import { MainServiceStub } from '../testing/stubs/services/main.service.stub';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
 import { BarsComponent } from './bars.component';
-import { BarsConfig, BarsLabelsConfig } from './bars.config';
+import { VicBarsConfig, VicBarsLabelsConfig } from './bars.config';
 
 describe('BarsComponent', () => {
   let component: BarsComponent;
@@ -404,7 +404,7 @@ describe('BarsComponent', () => {
       component.values = {
         x: [1, 2, 3, 4, -5],
       } as any;
-      component.config = new BarsConfig();
+      component.config = new VicBarsConfig();
       component.config.dimensions.quantitative = 'x';
     });
     it('integration: sets hasBarsWithNegativeValues to true if dataMin is less than zero', () => {
@@ -486,8 +486,8 @@ describe('BarsComponent', () => {
     beforeEach(() => {
       spyOn(component, 'drawBars');
       spyOn(component, 'drawBarLabels');
-      component.config = new BarsConfig();
-      component.config.labels = new BarsLabelsConfig();
+      component.config = new VicBarsConfig();
+      component.config.labels = new VicBarsLabelsConfig();
     });
     it('calls drawBars once with the correct parameter', () => {
       component.drawMarks(100);
@@ -508,7 +508,7 @@ describe('BarsComponent', () => {
 
   describe('getBarLabelText', () => {
     beforeEach(() => {
-      component.config = new BarsConfig();
+      component.config = new VicBarsConfig();
       component.config = {
         dimensions: { quantitative: 'x' },
         quantitative: {
@@ -547,8 +547,8 @@ describe('BarsComponent', () => {
   describe('getBarLabelColor', () => {
     beforeEach(() => {
       spyOn(component, 'getBarColor').and.returnValue('bar color');
-      component.config = new BarsConfig();
-      component.config.labels = new BarsLabelsConfig();
+      component.config = new VicBarsConfig();
+      component.config.labels = new VicBarsLabelsConfig();
     });
     describe('config.labels.color is defined', () => {
       beforeEach(() => {

--- a/projects/viz-components/src/lib/bars/bars.component.ts
+++ b/projects/viz-components/src/lib/bars/bars.component.ts
@@ -34,7 +34,7 @@ import { PatternUtilities } from '../shared/pattern-utilities.class';
 import { formatValue } from '../value-format/value-format';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
 import { XyContent } from '../xy-chart/xy-content';
-import { BarsConfig, BarsTooltipData } from './bars.config';
+import { VicBarsConfig, VicBarsTooltipData } from './bars.config';
 
 export const BARS = new InjectionToken<BarsComponent>('BarsComponent');
 @Component({
@@ -55,8 +55,8 @@ export class BarsComponent
   implements XyDataMarks, OnChanges, OnInit
 {
   @ViewChild('bars', { static: true }) barsRef: ElementRef<SVGSVGElement>;
-  @Input() config: BarsConfig;
-  @Output() tooltipData = new EventEmitter<BarsTooltipData>();
+  @Input() config: VicBarsConfig;
+  @Output() tooltipData = new EventEmitter<VicBarsTooltipData>();
   values: XyDataMarksValues = new XyDataMarksValues();
   hasBarsWithNegativeValues: boolean;
   barGroups: any;

--- a/projects/viz-components/src/lib/bars/bars.config.ts
+++ b/projects/viz-components/src/lib/bars/bars.config.ts
@@ -1,26 +1,27 @@
 import { scaleLinear } from 'd3';
 import {
-  CategoricalColorDimensionConfig,
-  OrdinalDimensionConfig,
-  QuantitativeDimensionConfig,
+  VicCategoricalColorDimensionConfig,
+  VicOrdinalDimensionConfig,
+  VicQuantitativeDimensionConfig,
 } from '../data-marks/data-dimension.config';
 import {
-  DataMarksConfig,
-  PatternPredicate,
+  VicDataMarksConfig,
+  VicPatternPredicate,
 } from '../data-marks/data-marks.config';
 
-export class BarsConfig extends DataMarksConfig {
-  ordinal: OrdinalDimensionConfig = new OrdinalDimensionConfig();
-  quantitative: QuantitativeDimensionConfig = new QuantitativeDimensionConfig();
-  category: CategoricalColorDimensionConfig =
-    new CategoricalColorDimensionConfig();
-  dimensions: BarsDimensionsConfig;
-  labels: BarsLabelsConfig;
-  patternPredicates?: PatternPredicate[];
+export class VicBarsConfig extends VicDataMarksConfig {
+  ordinal: VicOrdinalDimensionConfig = new VicOrdinalDimensionConfig();
+  quantitative: VicQuantitativeDimensionConfig =
+    new VicQuantitativeDimensionConfig();
+  category: VicCategoricalColorDimensionConfig =
+    new VicCategoricalColorDimensionConfig();
+  dimensions: VicBarsDimensionsConfig;
+  labels: VicBarsLabelsConfig;
+  patternPredicates?: VicPatternPredicate[];
 
-  constructor(init?: Partial<BarsConfig>) {
+  constructor(init?: Partial<VicBarsConfig>) {
     super();
-    this.dimensions = new VerticalBarChartDimensionsConfig();
+    this.dimensions = new VicVerticalBarChartDimensionsConfig();
     this.ordinal.valueAccessor = (d, i) => i;
     this.quantitative.valueAccessor = (d) => d;
     this.quantitative.scaleType = scaleLinear;
@@ -30,13 +31,13 @@ export class BarsConfig extends DataMarksConfig {
   }
 }
 
-export class BarsLabelsConfig {
+export class VicBarsLabelsConfig {
   display: boolean;
   offset: number;
   color?: string;
   noValueFunction: (d) => string;
 
-  constructor(init?: Partial<BarsLabelsConfig>) {
+  constructor(init?: Partial<VicBarsLabelsConfig>) {
     this.display = true;
     this.offset = 4;
     this.noValueFunction = (d) => 'N/A';
@@ -44,7 +45,7 @@ export class BarsLabelsConfig {
   }
 }
 
-export class BarsDimensionsConfig {
+export class VicBarsDimensionsConfig {
   direction: 'vertical' | 'horizontal';
   x: 'ordinal' | 'quantitative';
   y: 'ordinal' | 'quantitative';
@@ -52,12 +53,12 @@ export class BarsDimensionsConfig {
   quantitative: 'x' | 'y';
   quantitativeDimension: 'width' | 'height';
 
-  constructor(init?: Partial<BarsDimensionsConfig>) {
+  constructor(init?: Partial<VicBarsDimensionsConfig>) {
     Object.assign(this, init);
   }
 }
 
-export class HorizontalBarsDimensionsConfig extends BarsDimensionsConfig {
+export class VicHorizontalBarsDimensionsConfig extends VicBarsDimensionsConfig {
   constructor() {
     super();
     this.direction = 'horizontal';
@@ -69,7 +70,7 @@ export class HorizontalBarsDimensionsConfig extends BarsDimensionsConfig {
   }
 }
 
-export class VerticalBarChartDimensionsConfig extends BarsDimensionsConfig {
+export class VicVerticalBarChartDimensionsConfig extends VicBarsDimensionsConfig {
   constructor() {
     super();
     this.direction = 'vertical';
@@ -81,7 +82,7 @@ export class VerticalBarChartDimensionsConfig extends BarsDimensionsConfig {
   }
 }
 
-export class BarsTooltipData {
+export class VicBarsTooltipData {
   datum: any;
   value: string;
 }

--- a/projects/viz-components/src/lib/core/services/data-domain.service.ts
+++ b/projects/viz-components/src/lib/core/services/data-domain.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { DomainPaddingConfig } from '../../data-marks/data-dimension.config';
+import { VicDomainPaddingConfig } from '../../data-marks/data-dimension.config';
 import { ValueUtilities } from '../../shared/value-utilities.class';
 
 export type ValueType = 'max' | 'min';
@@ -10,7 +10,7 @@ export type ValueType = 'max' | 'min';
 export class DataDomainService {
   getPaddedDomainValue(
     unpaddedDomain: [number, number],
-    padding: DomainPaddingConfig,
+    padding: VicDomainPaddingConfig,
     valueType: ValueType,
     scaleType?: any,
     pixelRange?: [number, number]
@@ -97,7 +97,7 @@ export class DataDomainService {
 
   getQuantitativeDomain(
     unpaddedDomain: [number, number],
-    domainPadding: DomainPaddingConfig,
+    domainPadding: VicDomainPaddingConfig,
     scaleType?: any,
     pixelRange?: [number, number]
   ): [number, number] {

--- a/projects/viz-components/src/lib/data-marks/data-dimension.config.ts
+++ b/projects/viz-components/src/lib/data-marks/data-dimension.config.ts
@@ -1,100 +1,100 @@
 import { InternSet, scaleBand } from 'd3';
-import { FormatSpecifier } from '../value-format/value-format';
+import { VicFormatSpecifier } from '../value-format/value-format';
 
-export class DataDimensionConfig {
+export class VicDataDimensionConfig {
   valueAccessor: (...args: any) => any;
   domain?: any;
-  valueFormat?: FormatSpecifier;
-  constructor(init?: Partial<DataDimensionConfig>) {
+  valueFormat?: VicFormatSpecifier;
+  constructor(init?: Partial<VicDataDimensionConfig>) {
     Object.assign(this, init);
   }
 }
 
-export class QuantitativeDimensionConfig extends DataDimensionConfig {
+export class VicQuantitativeDimensionConfig extends VicDataDimensionConfig {
   override domain?: [any, any];
   scaleType?: (d: any, r: any) => any;
-  domainPadding: DomainPaddingConfig;
+  domainPadding: VicDomainPaddingConfig;
 
-  constructor(init?: Partial<QuantitativeDimensionConfig>) {
+  constructor(init?: Partial<VicQuantitativeDimensionConfig>) {
     super();
     Object.assign(this, init);
   }
 }
 
-export class BaseDomainPaddingConfig {
+export class VicBaseDomainPaddingConfig {
   sigDigits: (d: any) => number;
-  constructor(init?: Partial<BaseDomainPaddingConfig>) {
+  constructor(init?: Partial<VicBaseDomainPaddingConfig>) {
     this.sigDigits = () => 1;
     Object.assign(this, init);
   }
 }
 
-export class RoundUpDomainPaddingConfig extends BaseDomainPaddingConfig {
+export class VicRoundUpDomainPaddingConfig extends VicBaseDomainPaddingConfig {
   type: 'roundUp' = 'roundUp';
 
-  constructor(init?: Partial<RoundUpDomainPaddingConfig>) {
+  constructor(init?: Partial<VicRoundUpDomainPaddingConfig>) {
     super();
     Object.assign(this, init);
   }
 }
 
-export class RoundUpToIntervalDomainPaddingConfig extends BaseDomainPaddingConfig {
+export class VicRoundUpToIntervalDomainPaddingConfig extends VicBaseDomainPaddingConfig {
   type: 'roundInterval' = 'roundInterval';
   interval: (maxValue: number) => number;
 
-  constructor(init?: Partial<RoundUpToIntervalDomainPaddingConfig>) {
+  constructor(init?: Partial<VicRoundUpToIntervalDomainPaddingConfig>) {
     super();
     this.interval = () => 1;
     Object.assign(this, init);
   }
 }
 
-export class PercentOverDomainPaddingConfig extends BaseDomainPaddingConfig {
+export class VicPercentOverDomainPaddingConfig extends VicBaseDomainPaddingConfig {
   type: 'percentOver' = 'percentOver';
   percentOver: number;
 
-  constructor(init?: Partial<PercentOverDomainPaddingConfig>) {
+  constructor(init?: Partial<VicPercentOverDomainPaddingConfig>) {
     super();
     this.percentOver = 0.1;
     Object.assign(this, init);
   }
 }
 
-export class PixelDomainPaddingConfig extends BaseDomainPaddingConfig {
+export class VicPixelDomainPaddingConfig extends VicBaseDomainPaddingConfig {
   type: 'numPixels' = 'numPixels';
   numPixels: number;
 
-  constructor(init?: Partial<PixelDomainPaddingConfig>) {
+  constructor(init?: Partial<VicPixelDomainPaddingConfig>) {
     super();
     this.numPixels = 40;
     Object.assign(this, init);
   }
 }
 
-export type DomainPaddingConfig =
-  | RoundUpDomainPaddingConfig
-  | RoundUpToIntervalDomainPaddingConfig
-  | PercentOverDomainPaddingConfig
-  | PixelDomainPaddingConfig;
+export type VicDomainPaddingConfig =
+  | VicRoundUpDomainPaddingConfig
+  | VicRoundUpToIntervalDomainPaddingConfig
+  | VicPercentOverDomainPaddingConfig
+  | VicPixelDomainPaddingConfig;
 
-export class CategoricalColorDimensionConfig extends DataDimensionConfig {
+export class VicCategoricalColorDimensionConfig extends VicDataDimensionConfig {
   override domain?: any[] | InternSet;
   colorScale?: (...args: any) => any;
   colors?: string[];
-  constructor(init?: Partial<CategoricalColorDimensionConfig>) {
+  constructor(init?: Partial<VicCategoricalColorDimensionConfig>) {
     super();
     Object.assign(this, init);
   }
 }
 
-export class OrdinalDimensionConfig extends DataDimensionConfig {
+export class VicOrdinalDimensionConfig extends VicDataDimensionConfig {
   override domain?: any[] | InternSet;
   scaleType: (d: any, r: any) => any;
   paddingInner: number;
   paddingOuter: number;
   align: number;
 
-  constructor(init?: Partial<OrdinalDimensionConfig>) {
+  constructor(init?: Partial<VicOrdinalDimensionConfig>) {
     super();
     this.scaleType = scaleBand;
     this.paddingInner = 0.1;

--- a/projects/viz-components/src/lib/data-marks/data-marks.config.ts
+++ b/projects/viz-components/src/lib/data-marks/data-marks.config.ts
@@ -1,4 +1,4 @@
-export class DataMarksConfig {
+export class VicDataMarksConfig {
   /**
    * An array of data objects to be used to create marks.
    * The objects can be of an type, and can contain any number of properties, including properties that are extraneous to the chart at hand.
@@ -15,14 +15,14 @@ export class DataMarksConfig {
    */
   mixBlendMode: string;
 
-  constructor(init?: Partial<DataMarksConfig>) {
+  constructor(init?: Partial<VicDataMarksConfig>) {
     this.mixBlendMode = 'normal';
     this.data = [];
     Object.assign(this, init);
   }
 }
 
-export interface PatternPredicate {
+export interface VicPatternPredicate {
   patternName: string;
   predicate: (d: any) => boolean;
 }

--- a/projects/viz-components/src/lib/data-marks/data-marks.ts
+++ b/projects/viz-components/src/lib/data-marks/data-marks.ts
@@ -1,10 +1,10 @@
 import { Chart } from '../chart/chart';
 import { Ranges } from '../chart/chart.component';
-import { DataMarksConfig } from './data-marks.config';
+import { VicDataMarksConfig } from './data-marks.config';
 
 export class DataMarks {
   chart: Chart;
-  config: DataMarksConfig;
+  config: VicDataMarksConfig;
   ranges: Ranges;
   setMethodsFromConfigAndDraw: () => void;
   resizeMarks: () => void;

--- a/projects/viz-components/src/lib/export-data/data-export.config.ts
+++ b/projects/viz-components/src/lib/export-data/data-export.config.ts
@@ -1,15 +1,15 @@
 import { formatValue, valueFormat } from '../value-format/value-format';
 
-export class ColumnConfig {
+export class VicColumnConfig {
   title: string;
   valueAccessor: (x: any) => any;
 
-  constructor(init?: Partial<ColumnConfig>) {
+  constructor(init?: Partial<VicColumnConfig>) {
     Object.assign(this, init);
   }
 }
 
-export class DataExportConfig {
+export class VicDataExportConfig {
   data: unknown[];
   /**
    * If true, the data will be flipped.
@@ -49,16 +49,16 @@ export class DataExportConfig {
    * e.g. if there's a special title, the data needs to be formatted in some way,
    * sometimes certain fields are suppressed, etc.
    */
-  columns: ColumnConfig[] = [];
+  columns: VicColumnConfig[] = [];
   marginBottom = 0;
-  constructor(config?: Partial<DataExportConfig>) {
+  constructor(config?: Partial<VicDataExportConfig>) {
     Object.assign(this, config);
     if (this.includeAllKeysAsDefault) {
       this.defaultColumnList = Object.keys(this.data[0]);
     }
     this.defaultColumnList.forEach((key) => {
       this.columns.push(
-        new ColumnConfig({
+        new VicColumnConfig({
           title: key !== this.flippedHeaderKey ? this.convertToTitle(key) : key,
           valueAccessor: (x) =>
             x[key] instanceof Date

--- a/projects/viz-components/src/lib/export-data/export-data.service.spec.ts
+++ b/projects/viz-components/src/lib/export-data/export-data.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { VicExportDataService } from './export-data.service';
-import { DataExportConfig } from './data-export.config';
+import { VicDataExportConfig } from './data-export.config';
 
 describe('ExportDataService', () => {
   let service: VicExportDataService;
@@ -19,7 +19,7 @@ describe('ExportDataService', () => {
 
   describe('convertToTitle function', () => {
     it('should convert camel case to title', () => {
-      const dataExportConfig = new DataExportConfig();
+      const dataExportConfig = new VicDataExportConfig();
       expect(dataExportConfig.convertToTitle('thisString')).toBe('This String');
       expect(dataExportConfig.convertToTitle('123String')).toBe('123 String');
       expect(dataExportConfig.convertToTitle('123string')).toBe('123 string');

--- a/projects/viz-components/src/lib/export-data/export-data.service.ts
+++ b/projects/viz-components/src/lib/export-data/export-data.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@angular/core';
 import { saveAs } from 'file-saver';
 import { cloneDeep } from 'lodash-es';
 import { unparse } from 'papaparse';
-import { DataExportConfig } from './data-export.config';
+import { VicDataExportConfig } from './data-export.config';
 @Injectable()
 export class VicExportDataService {
-  saveCSV(name: string, dataConfigs: DataExportConfig[]): void {
+  saveCSV(name: string, dataConfigs: VicDataExportConfig[]): void {
     const blobParts = [];
     for (const dataConfig of dataConfigs) {
       let csv: string;

--- a/projects/viz-components/src/lib/geographies/geographies-click.directive.ts
+++ b/projects/viz-components/src/lib/geographies/geographies-click.directive.ts
@@ -17,7 +17,7 @@ import { GeographiesHoverMoveDirective } from './geographies-hover-move.directiv
 import { GeographiesHoverDirective } from './geographies-hover.directive';
 import { GeographiesInputEventDirective } from './geographies-input-event.directive';
 import {
-  GeographiesEventOutput,
+  VicGeographiesEventOutput,
   getGeographiesTooltipData,
 } from './geographies-tooltip-data';
 import { GEOGRAPHIES, GeographiesComponent } from './geographies.component';
@@ -38,7 +38,7 @@ export class GeographiesClickDirective<
   @Input('vicGeographiesClickRemoveEvent$')
   override clickRemoveEvent$: Observable<void>;
   @Output('vicGeographiesClickOutput') eventOutput =
-    new EventEmitter<GeographiesEventOutput>();
+    new EventEmitter<VicGeographiesEventOutput>();
   pointerX: number;
   pointerY: number;
   geographyIndex: number;
@@ -96,12 +96,12 @@ export class GeographiesClickDirective<
     return this.geographies.values.indexMap.get(value);
   }
 
-  getOutputData(): GeographiesEventOutput {
+  getOutputData(): VicGeographiesEventOutput {
     const tooltipData = getGeographiesTooltipData(
       this.geographyIndex,
       this.geographies
     );
-    const output: GeographiesEventOutput = {
+    const output: VicGeographiesEventOutput = {
       ...tooltipData,
       positionX: this.pointerX,
       positionY: this.pointerY,

--- a/projects/viz-components/src/lib/geographies/geographies-hover-move.directive.ts
+++ b/projects/viz-components/src/lib/geographies/geographies-hover-move.directive.ts
@@ -6,7 +6,7 @@ import { filter, takeUntil } from 'rxjs';
 import { HoverMoveEventEffect } from '../events/effect';
 import { HoverMoveDirective } from '../events/hover-move.directive';
 import {
-  GeographiesEventOutput,
+  VicGeographiesEventOutput,
   getGeographiesTooltipData,
 } from './geographies-tooltip-data';
 import { GEOGRAPHIES, GeographiesComponent } from './geographies.component';
@@ -18,7 +18,7 @@ export class GeographiesHoverMoveDirective extends HoverMoveDirective {
   @Input('vicGeographiesHoverMoveEffects')
   effects: HoverMoveEventEffect<GeographiesHoverMoveDirective>[];
   @Output('vicGeographiesHoverMoveOutput') eventOutput =
-    new EventEmitter<GeographiesEventOutput>();
+    new EventEmitter<VicGeographiesEventOutput>();
   pointerX: number;
   pointerY: number;
   geographyIndex: number;
@@ -72,12 +72,12 @@ export class GeographiesHoverMoveDirective extends HoverMoveDirective {
     return this.geographies.values.indexMap.get(value);
   }
 
-  getEventOutput(): GeographiesEventOutput {
+  getEventOutput(): VicGeographiesEventOutput {
     const tooltipData = getGeographiesTooltipData(
       this.geographyIndex,
       this.geographies
     );
-    const output: GeographiesEventOutput = {
+    const output: VicGeographiesEventOutput = {
       ...tooltipData,
       positionX: this.pointerX,
       positionY: this.pointerY,

--- a/projects/viz-components/src/lib/geographies/geographies-hover.directive.ts
+++ b/projects/viz-components/src/lib/geographies/geographies-hover.directive.ts
@@ -7,8 +7,8 @@ import { filter, takeUntil } from 'rxjs';
 import { EventEffect } from '../events/effect';
 import { HoverDirective } from '../events/hover.directive';
 import {
-  GeographiesEventOutput,
-  GeographiesTooltipOutput,
+  VicGeographiesEventOutput,
+  VicGeographiesTooltipOutput,
   getGeographiesTooltipData,
 } from './geographies-tooltip-data';
 import { GEOGRAPHIES, GeographiesComponent } from './geographies.component';
@@ -18,7 +18,7 @@ interface GeographiesHoverExtras {
   bounds?: [[number, number], [number, number]];
 }
 
-export type GeographiesHoverOutput = GeographiesTooltipOutput &
+export type GeographiesHoverOutput = VicGeographiesTooltipOutput &
   GeographiesHoverExtras;
 
 @Directive({
@@ -30,7 +30,7 @@ export class GeographiesHoverDirective<
   @Input('vicGeographiesHoverEffects')
   effects: EventEffect<GeographiesHoverDirective<T>>[];
   @Output('vicGeographiesHoverOutput') eventOutput =
-    new EventEmitter<GeographiesEventOutput>();
+    new EventEmitter<VicGeographiesEventOutput>();
   feature: Feature;
   bounds: [[number, number], [number, number]];
   geographyIndex: number;
@@ -78,7 +78,7 @@ export class GeographiesHoverDirective<
     return this.geographies.values.indexMap.get(value);
   }
 
-  getEventOutput(): GeographiesEventOutput {
+  getEventOutput(): VicGeographiesEventOutput {
     const tooltipData = getGeographiesTooltipData(
       this.geographyIndex,
       this.geographies

--- a/projects/viz-components/src/lib/geographies/geographies-tooltip-data.ts
+++ b/projects/viz-components/src/lib/geographies/geographies-tooltip-data.ts
@@ -1,14 +1,14 @@
 import { formatValue } from '../value-format/value-format';
 import { GeographiesComponent } from './geographies.component';
 
-export interface GeographiesTooltipOutput {
+export interface VicGeographiesTooltipOutput {
   datum?: any;
   color: string;
   geography: string;
   attributeValue: string;
 }
 
-export interface GeographiesEventOutput extends GeographiesTooltipOutput {
+export interface VicGeographiesEventOutput extends VicGeographiesTooltipOutput {
   positionX: number;
   positionY: number;
 }
@@ -16,7 +16,7 @@ export interface GeographiesEventOutput extends GeographiesTooltipOutput {
 export function getGeographiesTooltipData(
   geographyIndex: number,
   geographies: GeographiesComponent
-): GeographiesTooltipOutput {
+): VicGeographiesTooltipOutput {
   const datum = geographies.config.data.find(
     (d) =>
       geographies.config.dataGeographyConfig.attributeDataConfig
@@ -25,7 +25,7 @@ export function getGeographiesTooltipData(
       geographies.values.attributeDataGeographies[geographyIndex]
   );
 
-  const tooltipData: GeographiesTooltipOutput = {
+  const tooltipData: VicGeographiesTooltipOutput = {
     datum,
     geography:
       geographies.config.dataGeographyConfig.attributeDataConfig.geoAccessor(

--- a/projects/viz-components/src/lib/geographies/geographies.component.spec.ts
+++ b/projects/viz-components/src/lib/geographies/geographies.component.spec.ts
@@ -6,13 +6,13 @@ import { MapChartComponent } from '../map-chart/map-chart.component';
 import { MainServiceStub } from '../testing/stubs/services/main.service.stub';
 import { GeographiesComponent, MapDataValues } from './geographies.component';
 import {
-  CategoricalAttributeDataDimensionConfig,
-  CustomBreaksQuantitativeAttributeDataDimensionConfig,
-  DataGeographyConfig,
-  EqualNumbersQuantitativeAttributeDataDimensionConfig,
-  EqualValuesQuantitativeAttributeDataDimensionConfig,
-  GeographiesConfig,
-  NoBinsQuantitativeAttributeDataDimensionConfig,
+  VicCategoricalAttributeDataDimensionConfig,
+  VicCustomBreaksQuantitativeAttributeDataDimensionConfig,
+  VicDataGeographyConfig,
+  VicEqualNumbersQuantitativeAttributeDataDimensionConfig,
+  VicEqualValuesQuantitativeAttributeDataDimensionConfig,
+  VicGeographiesConfig,
+  VicNoBinsQuantitativeAttributeDataDimensionConfig,
 } from './geographies.config';
 
 describe('GeographiesComponent', () => {
@@ -38,7 +38,7 @@ describe('GeographiesComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GeographiesComponent);
     component = fixture.componentInstance;
-    component.config = new GeographiesConfig();
+    component.config = new VicGeographiesConfig();
   });
 
   describe('ngOnChanges()', () => {
@@ -158,14 +158,14 @@ describe('GeographiesComponent', () => {
 
   describe('integration: setting attribute data scale domain', () => {
     beforeEach(() => {
-      component.config = new GeographiesConfig();
-      component.config.dataGeographyConfig = new DataGeographyConfig();
+      component.config = new VicGeographiesConfig();
+      component.config.dataGeographyConfig = new VicDataGeographyConfig();
       component.values = new MapDataValues();
     });
     describe('categorical attribute data', () => {
       beforeEach(() => {
         component.config.dataGeographyConfig.attributeDataConfig =
-          new CategoricalAttributeDataDimensionConfig();
+          new VicCategoricalAttributeDataDimensionConfig();
         component.values.attributeDataValues = ['a', 'a', 'b', 'b', 'c', 'c'];
       });
       it('sets the domain to the correct value, user did not specify domain', () => {
@@ -194,7 +194,7 @@ describe('GeographiesComponent', () => {
     describe('quantitative attribute data: no bins', () => {
       beforeEach(() => {
         component.config.dataGeographyConfig.attributeDataConfig =
-          new NoBinsQuantitativeAttributeDataDimensionConfig();
+          new VicNoBinsQuantitativeAttributeDataDimensionConfig();
         component.values.attributeDataValues = [1, 3, 5, 9, 10, 11];
       });
       it('sets the domain to the correct value, user did not specify domain', () => {
@@ -216,7 +216,7 @@ describe('GeographiesComponent', () => {
     describe('quantitative attribute data: equal num observations', () => {
       beforeEach(() => {
         component.config.dataGeographyConfig.attributeDataConfig =
-          new EqualNumbersQuantitativeAttributeDataDimensionConfig();
+          new VicEqualNumbersQuantitativeAttributeDataDimensionConfig();
         component.config.dataGeographyConfig.attributeDataConfig.numBins = 3;
         component.values.attributeDataValues = [1, 3, 5, 9, 10, 11];
       });
@@ -230,7 +230,7 @@ describe('GeographiesComponent', () => {
     describe('quantitative attribute data: equal values', () => {
       beforeEach(() => {
         component.config.dataGeographyConfig.attributeDataConfig =
-          new EqualValuesQuantitativeAttributeDataDimensionConfig();
+          new VicEqualValuesQuantitativeAttributeDataDimensionConfig();
         component.config.dataGeographyConfig.attributeDataConfig.numBins = 3;
         component.values.attributeDataValues = [1, 3, 5, 9, 10, 12];
       });
@@ -283,7 +283,7 @@ describe('GeographiesComponent', () => {
     describe('quantitative attribute data: custom breaks', () => {
       beforeEach(() => {
         component.config.dataGeographyConfig.attributeDataConfig =
-          new CustomBreaksQuantitativeAttributeDataDimensionConfig();
+          new VicCustomBreaksQuantitativeAttributeDataDimensionConfig();
         component.config.dataGeographyConfig.attributeDataConfig.numBins = 3;
         component.config.dataGeographyConfig.attributeDataConfig.breakValues = [
           0, 2, 4, 6, 8,

--- a/projects/viz-components/src/lib/geographies/geographies.component.ts
+++ b/projects/viz-components/src/lib/geographies/geographies.component.ts
@@ -31,9 +31,9 @@ import { MapContent } from '../map-chart/map-content';
 import { PatternUtilities } from '../shared/pattern-utilities.class';
 import { formatValue } from '../value-format/value-format';
 import {
-  DataGeographyConfig,
-  GeographiesConfig,
-  NoDataGeographyConfig,
+  VicDataGeographyConfig,
+  VicGeographiesConfig,
+  VicNoDataGeographyConfig,
 } from './geographies.config';
 
 export class MapDataValues {
@@ -70,7 +70,7 @@ export class GeographiesComponent
   extends MapContent
   implements DataMarks, OnChanges, OnInit
 {
-  @Input() config: GeographiesConfig;
+  @Input() config: VicGeographiesConfig;
   ranges: Ranges;
   map: any;
   projection: any;
@@ -387,7 +387,7 @@ export class GeographiesComponent
 
     this.map
       .selectAll('path')
-      .data((layer: DataGeographyConfig) => layer.geographies)
+      .data((layer: VicDataGeographyConfig) => layer.geographies)
       .join(
         (enter) => {
           enter = enter.append('path');
@@ -422,7 +422,7 @@ export class GeographiesComponent
 
     noDataLayers
       .selectAll('path')
-      .data((layer: NoDataGeographyConfig) => layer.geographies)
+      .data((layer: VicNoDataGeographyConfig) => layer.geographies)
       .join(
         (enter) =>
           enter
@@ -471,7 +471,7 @@ export class GeographiesComponent
   }
 
   getNoDataGeographyPatternFill(node: any): string {
-    const config: NoDataGeographyConfig = this.getConfigFromNode(node);
+    const config: VicNoDataGeographyConfig = this.getConfigFromNode(node);
     return config.patternName ? `url(#${config.patternName})` : config.fill;
   }
 

--- a/projects/viz-components/src/lib/geographies/geographies.config.ts
+++ b/projects/viz-components/src/lib/geographies/geographies.config.ts
@@ -13,17 +13,17 @@ import {
   scaleThreshold,
 } from 'd3';
 import { Feature } from 'geojson';
-import { DataDimensionConfig } from '../data-marks/data-dimension.config';
+import { VicDataDimensionConfig as VicDataDimensionConfig } from '../data-marks/data-dimension.config';
 import {
-  DataMarksConfig,
-  PatternPredicate,
+  VicDataMarksConfig as VicDataMarksConfig,
+  VicPatternPredicate as VicPatternPredicate,
 } from '../data-marks/data-marks.config';
 
 /** Primary configuration object to specify a map with attribute data, intended to be used with GeographiesComponent.
  * Note that while a GeographiesComponent can create geographies without attribute data, for example, to create an
  * outline of a geographic area, it is not intended to draw maps that have no attribute data.
  */
-export class GeographiesConfig extends DataMarksConfig {
+export class VicGeographiesConfig extends VicDataMarksConfig {
   /** A feature or geometry object or collection that defines the extents of the map to be drawn.
    * Used for scaling the map.
    */
@@ -40,20 +40,20 @@ export class GeographiesConfig extends DataMarksConfig {
   /**
    * A configuration object that pertains to geographies that have no attribute data, for example the outline of a country.
    */
-  noDataGeographiesConfigs?: NoDataGeographyConfig[];
+  noDataGeographiesConfigs?: VicNoDataGeographyConfig[];
   /**
    * A configuration object that pertains to geographies that have attribute data, for example, states in the US each of which have a value for % unemployment.
    */
-  dataGeographyConfig: DataGeographyConfig;
+  dataGeographyConfig: VicDataGeographyConfig;
 
-  constructor(init?: Partial<GeographiesConfig>) {
+  constructor(init?: Partial<VicGeographiesConfig>) {
     super();
     this.projection = geoAlbersUsa();
     Object.assign(this, init);
   }
 }
 
-export class BaseDataGeographyConfig {
+export class VicBaseDataGeographyConfig {
   /**
    * GeoJSON features that define the geographies to be drawn.
    */
@@ -75,13 +75,13 @@ export class BaseDataGeographyConfig {
   fill: string;
 }
 
-export class NoDataGeographyConfig extends BaseDataGeographyConfig {
+export class VicNoDataGeographyConfig extends VicBaseDataGeographyConfig {
   /**
    * The pattern for noDataGeography. If provided, fill will be overridden.
    */
   patternName: string;
 
-  constructor(init?: Partial<NoDataGeographyConfig>) {
+  constructor(init?: Partial<VicNoDataGeographyConfig>) {
     super();
     this.strokeColor = 'dimgray';
     this.strokeWidth = '1';
@@ -90,45 +90,45 @@ export class NoDataGeographyConfig extends BaseDataGeographyConfig {
   }
 }
 
-export class DataGeographyConfig extends BaseDataGeographyConfig {
+export class VicDataGeographyConfig extends VicBaseDataGeographyConfig {
   valueAccessor?: (d: any) => any;
-  attributeDataConfig: AttributeDataDimensionConfig;
+  attributeDataConfig: VicAttributeDataDimensionConfig;
   nullColor: string;
 
-  constructor(init?: Partial<DataGeographyConfig>) {
+  constructor(init?: Partial<VicDataGeographyConfig>) {
     super();
     this.nullColor = '#dcdcdc';
     Object.assign(this, init);
   }
 }
 
-export class AttributeDataDimensionConfig extends DataDimensionConfig {
+export class VicAttributeDataDimensionConfig extends VicDataDimensionConfig {
   geoAccessor: (d: any) => any;
   valueType: string;
-  binType: MapBinType;
+  binType: VicMapBinType;
   range: any[];
   colorScale: (...args: any) => any;
   colors?: string[];
   numBins?: number;
   breakValues?: number[];
   interpolator: (...args: any) => any;
-  patternPredicates?: PatternPredicate[];
-  constructor(init?: Partial<AttributeDataDimensionConfig>) {
+  patternPredicates?: VicPatternPredicate[];
+  constructor(init?: Partial<VicAttributeDataDimensionConfig>) {
     super();
     Object.assign(this, init);
   }
 }
 
-export type MapBinType =
+export type VicMapBinType =
   | 'none'
   | 'equal value ranges'
   | 'equal num observations'
   | 'custom breaks';
 
-export class CategoricalAttributeDataDimensionConfig extends AttributeDataDimensionConfig {
+export class VicCategoricalAttributeDataDimensionConfig extends VicAttributeDataDimensionConfig {
   override interpolator: never;
 
-  constructor(init?: Partial<CategoricalAttributeDataDimensionConfig>) {
+  constructor(init?: Partial<VicCategoricalAttributeDataDimensionConfig>) {
     super();
     this.valueType = 'categorical';
     this.binType = 'none';
@@ -137,8 +137,10 @@ export class CategoricalAttributeDataDimensionConfig extends AttributeDataDimens
     Object.assign(this, init);
   }
 }
-export class NoBinsQuantitativeAttributeDataDimensionConfig extends AttributeDataDimensionConfig {
-  constructor(init?: Partial<NoBinsQuantitativeAttributeDataDimensionConfig>) {
+export class VicNoBinsQuantitativeAttributeDataDimensionConfig extends VicAttributeDataDimensionConfig {
+  constructor(
+    init?: Partial<VicNoBinsQuantitativeAttributeDataDimensionConfig>
+  ) {
     super();
     this.valueType = 'quantitative';
     this.binType = 'none';
@@ -148,9 +150,9 @@ export class NoBinsQuantitativeAttributeDataDimensionConfig extends AttributeDat
   }
 }
 
-export class EqualValuesQuantitativeAttributeDataDimensionConfig extends AttributeDataDimensionConfig {
+export class VicEqualValuesQuantitativeAttributeDataDimensionConfig extends VicAttributeDataDimensionConfig {
   constructor(
-    init?: Partial<EqualValuesQuantitativeAttributeDataDimensionConfig>
+    init?: Partial<VicEqualValuesQuantitativeAttributeDataDimensionConfig>
   ) {
     super();
     this.valueType = 'quantitative';
@@ -162,10 +164,10 @@ export class EqualValuesQuantitativeAttributeDataDimensionConfig extends Attribu
   }
 }
 
-export class EqualNumbersQuantitativeAttributeDataDimensionConfig extends AttributeDataDimensionConfig {
+export class VicEqualNumbersQuantitativeAttributeDataDimensionConfig extends VicAttributeDataDimensionConfig {
   override domain: never;
   constructor(
-    init?: Partial<EqualNumbersQuantitativeAttributeDataDimensionConfig>
+    init?: Partial<VicEqualNumbersQuantitativeAttributeDataDimensionConfig>
   ) {
     super();
     this.valueType = 'quantitative';
@@ -177,9 +179,9 @@ export class EqualNumbersQuantitativeAttributeDataDimensionConfig extends Attrib
   }
 }
 
-export class CustomBreaksQuantitativeAttributeDataDimensionConfig extends AttributeDataDimensionConfig {
+export class VicCustomBreaksQuantitativeAttributeDataDimensionConfig extends VicAttributeDataDimensionConfig {
   constructor(
-    init?: Partial<CustomBreaksQuantitativeAttributeDataDimensionConfig>
+    init?: Partial<VicCustomBreaksQuantitativeAttributeDataDimensionConfig>
   ) {
     super();
     this.valueType = 'quantitative';

--- a/projects/viz-components/src/lib/grouped-bars/grouped-bars.component.ts
+++ b/projects/viz-components/src/lib/grouped-bars/grouped-bars.component.ts
@@ -7,7 +7,7 @@ import {
 import { InternSet, range, scaleBand } from 'd3';
 import { BarsComponent } from '../bars/bars.component';
 import { DATA_MARKS } from '../data-marks/data-marks.token';
-import { GroupedBarsConfig } from './grouped-bars.config';
+import { VicGroupedBarsConfig } from './grouped-bars.config';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -19,7 +19,7 @@ import { GroupedBarsConfig } from './grouped-bars.config';
   providers: [{ provide: DATA_MARKS, useExisting: GroupedBarsComponent }],
 })
 export class GroupedBarsComponent extends BarsComponent {
-  @Input() override config: GroupedBarsConfig;
+  @Input() override config: VicGroupedBarsConfig;
   groupScale: any;
 
   override setMethodsFromConfigAndDraw(): void {

--- a/projects/viz-components/src/lib/grouped-bars/grouped-bars.config.ts
+++ b/projects/viz-components/src/lib/grouped-bars/grouped-bars.config.ts
@@ -1,8 +1,8 @@
-import { BarsConfig } from '../bars/bars.config';
+import { VicBarsConfig } from '../bars/bars.config';
 
-export class GroupedBarsConfig extends BarsConfig {
+export class VicGroupedBarsConfig extends VicBarsConfig {
   intraGroupPadding: number;
-  constructor(init?: Partial<GroupedBarsConfig>) {
+  constructor(init?: Partial<VicGroupedBarsConfig>) {
     super();
     this.intraGroupPadding = 0.05;
     Object.assign(this, init);

--- a/projects/viz-components/src/lib/lines/lines-click.directive.ts
+++ b/projects/viz-components/src/lib/lines/lines-click.directive.ts
@@ -17,7 +17,7 @@ import { LinesHoverDirective } from './lines-hover.directive';
 import { LinesInputEventDirective } from './lines-input-event.directive';
 import {
   getLinesTooltipDataFromDatum,
-  LinesEventOutput,
+  VicLinesEventOutput,
 } from './lines-tooltip-data';
 import { LINES, LinesComponent } from './lines.component';
 
@@ -37,7 +37,7 @@ export class LinesClickDirective<
   @Input('vicLinesChartClickRemoveEvent$')
   override clickRemoveEvent$: Observable<void>;
   @Output('vicLinesChartClickOutput') eventOutput =
-    new EventEmitter<LinesEventOutput>();
+    new EventEmitter<VicLinesEventOutput>();
 
   constructor(
     @Inject(LINES) public lines: LinesComponent,
@@ -67,7 +67,7 @@ export class LinesClickDirective<
     this.effects.forEach((effect) => effect.removeEffect(this));
   }
 
-  getOutputData(): LinesEventOutput {
+  getOutputData(): VicLinesEventOutput {
     if (!this.hoverAndMoveDirective) {
       console.warn(
         'Tooltip data can only be retrieved when a LinesHoverMoveDirective is implemented.'

--- a/projects/viz-components/src/lib/lines/lines-hover-move.directive.ts
+++ b/projects/viz-components/src/lib/lines/lines-hover-move.directive.ts
@@ -6,7 +6,7 @@ import { HoverMoveEventEffect } from '../events/effect';
 import { HoverMoveDirective } from '../events/hover-move.directive';
 import {
   getLinesTooltipDataFromDatum,
-  LinesEventOutput,
+  VicLinesEventOutput,
 } from './lines-tooltip-data';
 import { LINES, LinesComponent } from './lines.component';
 
@@ -19,7 +19,7 @@ export class LinesHoverMoveDirective<
   @Input('vicLinesHoverMoveEffects')
   effects: HoverMoveEventEffect<LinesHoverMoveDirective<T>>[];
   @Output('vicLinesHoverMoveOutput') eventOutput =
-    new EventEmitter<LinesEventOutput>();
+    new EventEmitter<VicLinesEventOutput>();
   pointerX: number;
   pointerY: number;
   closestPointIndex: number;
@@ -131,7 +131,7 @@ export class LinesHoverMoveDirective<
     }
   }
 
-  getEventOutput(): LinesEventOutput {
+  getEventOutput(): VicLinesEventOutput {
     const data = getLinesTooltipDataFromDatum(
       this.closestPointIndex,
       this.lines

--- a/projects/viz-components/src/lib/lines/lines-marker-click.directive.ts
+++ b/projects/viz-components/src/lib/lines/lines-marker-click.directive.ts
@@ -18,7 +18,7 @@ import { LinesHoverDirective } from './lines-hover.directive';
 import { LinesInputEventDirective } from './lines-input-event.directive';
 import {
   getLinesTooltipDataFromDatum,
-  LinesEventOutput,
+  VicLinesEventOutput,
 } from './lines-tooltip-data';
 import { LINES, LinesComponent } from './lines.component';
 
@@ -55,11 +55,11 @@ export class LinesMarkerClickDirective<
   @Input('vicLinesMarkerClickRemoveEvent$')
   override clickRemoveEvent$: Observable<void>;
   /**
-   * An `EventEmitter` that emits a [LinesEmittedOutput]{@link LinesEventOutput} object if
+   * An `EventEmitter` that emits a [LinesEmittedOutput]{@link VicLinesEventOutput} object if
    *  an `applyEffect` or a `removeEffect` method calls `next` on it.
    */
   @Output('vicLinesMarkerClickOutput') eventOutput =
-    new EventEmitter<LinesEventOutput>();
+    new EventEmitter<VicLinesEventOutput>();
   /**
    * The index of the point that was clicked in the LinesComponent's values array.
    */
@@ -99,7 +99,7 @@ export class LinesMarkerClickDirective<
     this.effects.forEach((effect) => effect.removeEffect(this));
   }
 
-  getTooltipData(): LinesEventOutput {
+  getTooltipData(): VicLinesEventOutput {
     const data = getLinesTooltipDataFromDatum(this.pointIndex, this.lines);
     return data;
   }

--- a/projects/viz-components/src/lib/lines/lines-tooltip-data.ts
+++ b/projects/viz-components/src/lib/lines/lines-tooltip-data.ts
@@ -1,7 +1,7 @@
 import { formatValue } from '../value-format/value-format';
 import { LinesComponent } from './lines.component';
 
-export interface LinesEventOutput {
+export interface VicLinesEventOutput {
   datum: any;
   x: string;
   y: string;
@@ -14,7 +14,7 @@ export interface LinesEventOutput {
 export function getLinesTooltipDataFromDatum(
   datumIndex: number,
   lines: LinesComponent
-): LinesEventOutput {
+): VicLinesEventOutput {
   const datum = lines.config.data.find(
     (d) =>
       lines.values.x[datumIndex] === lines.config.x.valueAccessor(d) &&

--- a/projects/viz-components/src/lib/lines/lines.component.spec.ts
+++ b/projects/viz-components/src/lib/lines/lines.component.spec.ts
@@ -5,7 +5,7 @@ import { UtilitiesService } from '../core/services/utilities.service';
 import { MainServiceStub } from '../testing/stubs/services/main.service.stub';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
 import { LinesComponent } from './lines.component';
-import { LinesConfig } from './lines.config';
+import { VicLinesConfig } from './lines.config';
 
 describe('LineChartComponent', () => {
   let component: LinesComponent;
@@ -30,7 +30,7 @@ describe('LineChartComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LinesComponent);
     component = fixture.componentInstance;
-    component.config = new LinesConfig();
+    component.config = new VicLinesConfig();
   });
 
   describe('ngOnChanges()', () => {
@@ -296,7 +296,7 @@ describe('LineChartComponent', () => {
       spyOn(component, 'drawLines');
       spyOn(component, 'drawPointMarkers');
       spyOn(component, 'drawLineLabels');
-      component.config = new LinesConfig();
+      component.config = new VicLinesConfig();
     });
     it('calls drawLines once and with the correct argument', () => {
       component.drawMarks(duration);

--- a/projects/viz-components/src/lib/lines/lines.component.ts
+++ b/projects/viz-components/src/lib/lines/lines.component.ts
@@ -34,9 +34,9 @@ import { DATA_MARKS } from '../data-marks/data-marks.token';
 import { XyDataMarks, XyDataMarksValues } from '../data-marks/xy-data-marks';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
 import { XyContent } from '../xy-chart/xy-content';
-import { LinesConfig } from './lines.config';
+import { VicLinesConfig } from './lines.config';
 import { DataDomainService } from '../core/services/data-domain.service';
-import { DomainPaddingConfig } from '../data-marks/data-dimension.config';
+import { VicDomainPaddingConfig } from '../data-marks/data-dimension.config';
 
 export interface Marker {
   key: string;
@@ -75,7 +75,7 @@ export class LinesComponent
   @ViewChild('markers', { static: true }) markersRef: ElementRef<SVGSVGElement>;
   @ViewChild('lineLabels', { static: true })
   lineLabelsRef: ElementRef<SVGSVGElement>;
-  @Input() config: LinesConfig;
+  @Input() config: VicLinesConfig;
   values: XyDataMarksValues = new XyDataMarksValues();
   line: (x: any[]) => any;
   linesD3Data;
@@ -188,7 +188,7 @@ export class LinesComponent
 
   getNewDomain(
     scaleType: any,
-    domainPadding: DomainPaddingConfig,
+    domainPadding: VicDomainPaddingConfig,
     domain: [any, any],
     pixelRange: [number, number]
   ): [any, any] {

--- a/projects/viz-components/src/lib/lines/lines.config.ts
+++ b/projects/viz-components/src/lib/lines/lines.config.ts
@@ -1,11 +1,11 @@
 import { curveLinear, scaleLinear, scaleUtc, schemeTableau10 } from 'd3';
 import {
-  CategoricalColorDimensionConfig,
-  QuantitativeDimensionConfig,
+  VicCategoricalColorDimensionConfig,
+  VicQuantitativeDimensionConfig,
 } from '../data-marks/data-dimension.config';
-import { DataMarksConfig } from '../data-marks/data-marks.config';
+import { VicDataMarksConfig } from '../data-marks/data-marks.config';
 
-export class LinesConfig extends DataMarksConfig {
+export class VicLinesConfig extends VicDataMarksConfig {
   /**
    * A config for the behavior of the chart's x dimension
    *
@@ -13,7 +13,7 @@ export class LinesConfig extends DataMarksConfig {
    *
    * Default scaleType is D3's [scaleUtc]{@link https://github.com/d3/d3-scale#scaleUtc}.
    */
-  x: QuantitativeDimensionConfig = new QuantitativeDimensionConfig();
+  x: VicQuantitativeDimensionConfig = new VicQuantitativeDimensionConfig();
 
   /**
    * A config for the behavior of the chart's y dimension
@@ -22,7 +22,7 @@ export class LinesConfig extends DataMarksConfig {
    *
    * Default scaleType is D3's [scaleLinear]{@link https://github.com/d3/d3-scale#scaleLinear}.
    */
-  y: QuantitativeDimensionConfig = new QuantitativeDimensionConfig();
+  y: VicQuantitativeDimensionConfig = new VicQuantitativeDimensionConfig();
 
   /**
    * A config for the behavior of the chart's category dimension.
@@ -31,8 +31,8 @@ export class LinesConfig extends DataMarksConfig {
    *
    * Default colors array is D3's [schemeTableau10]{@link https://github.com/d3/d3-scale-chromatic#schemeTableau10}.
    */
-  category: CategoricalColorDimensionConfig =
-    new CategoricalColorDimensionConfig();
+  category: VicCategoricalColorDimensionConfig =
+    new VicCategoricalColorDimensionConfig();
 
   /**
    * A function that returns a boolean indicating whether a value in the data is defined.
@@ -54,19 +54,19 @@ export class LinesConfig extends DataMarksConfig {
   /**
    * A config for the behavior of markers for each datum on the line.
    */
-  pointMarkers: PointMarkersConfig = new PointMarkersConfig();
+  pointMarkers: VicPointMarkersConfig = new VicPointMarkersConfig();
 
   /**
    * A config for a dot that will appear on hover of a line. Intended to be used when there
    *  are no point markers along the line (i.e. at all points), particularly when a tooltip with point-specific
    *  data will be displayed. Will not be displayed if pointMarkers.display is true.
    */
-  hoverDot: PointMarkerConfig = new PointMarkerConfig();
+  hoverDot: VicPointMarkerConfig = new VicPointMarkerConfig();
 
   /**
    * A config for the behavior of the line stroke.
    */
-  stroke?: LinesStrokeConfig = new LinesStrokeConfig();
+  stroke?: VicLinesStrokeConfig = new VicLinesStrokeConfig();
 
   /**
    * A boolean to determine if the line will be labeled.
@@ -89,7 +89,7 @@ export class LinesConfig extends DataMarksConfig {
    */
   pointerDetectionRadius: number;
 
-  constructor(init?: Partial<LinesConfig>) {
+  constructor(init?: Partial<VicLinesConfig>) {
     super();
     this.x.valueAccessor = ([x]) => x;
     this.x.scaleType = scaleUtc;
@@ -105,7 +105,7 @@ export class LinesConfig extends DataMarksConfig {
   }
 }
 
-export class LinesStrokeConfig {
+export class VicLinesStrokeConfig {
   /**
    * A value for the line's [stroke-linecap]{@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap}
    *  attribute.
@@ -138,7 +138,7 @@ export class LinesStrokeConfig {
    */
   width: number;
 
-  constructor(init?: Partial<LinesStrokeConfig>) {
+  constructor(init?: Partial<VicLinesStrokeConfig>) {
     this.linecap = 'round';
     this.linejoin = 'round';
     this.opacity = 1;
@@ -147,7 +147,7 @@ export class LinesStrokeConfig {
   }
 }
 
-export class PointMarkerConfig {
+export class VicPointMarkerConfig {
   /**
    * A boolean to determine if point markers will be displayed.
    *
@@ -162,14 +162,14 @@ export class PointMarkerConfig {
    */
   radius: number;
 
-  constructor(init?: Partial<PointMarkerConfig>) {
+  constructor(init?: Partial<VicPointMarkerConfig>) {
     this.display = false;
     this.radius = 3;
     Object.assign(this, init);
   }
 }
 
-export class PointMarkersConfig extends PointMarkerConfig {
+export class VicPointMarkersConfig extends VicPointMarkerConfig {
   /**
    * A value by which the point marker will expand on hover, in px.
    *
@@ -177,7 +177,7 @@ export class PointMarkersConfig extends PointMarkerConfig {
    */
   growByOnHover: number;
 
-  constructor(init?: Partial<PointMarkersConfig>) {
+  constructor(init?: Partial<VicPointMarkersConfig>) {
     super();
     this.display = true;
     this.growByOnHover = 1;

--- a/projects/viz-components/src/lib/map-chart/map-chart.component.ts
+++ b/projects/viz-components/src/lib/map-chart/map-chart.component.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Chart } from '../chart/chart';
 import { ChartComponent } from '../chart/chart.component';
 import { CHART } from '../chart/chart.token';
-import { AttributeDataDimensionConfig } from '../geographies/geographies.config';
+import { VicAttributeDataDimensionConfig } from '../geographies/geographies.config';
 
 /**
  * A `Chart` component to be used with a `Geographies` `DataMarks` component.
@@ -33,7 +33,7 @@ import { AttributeDataDimensionConfig } from '../geographies/geographies.config'
   providers: [{ provide: CHART, useExisting: ChartComponent }],
 })
 export class MapChartComponent extends ChartComponent implements Chart {
-  private attributeDataConfig: BehaviorSubject<AttributeDataDimensionConfig> =
+  private attributeDataConfig: BehaviorSubject<VicAttributeDataDimensionConfig> =
     new BehaviorSubject(null);
   attributeDataConfig$ = this.attributeDataConfig.asObservable();
   private attributeDataScale: BehaviorSubject<any> = new BehaviorSubject(null);
@@ -43,7 +43,7 @@ export class MapChartComponent extends ChartComponent implements Chart {
     this.attributeDataScale.next(dataScale);
   }
 
-  updateAttributeDataConfig(dataConfig: AttributeDataDimensionConfig): void {
+  updateAttributeDataConfig(dataConfig: VicAttributeDataDimensionConfig): void {
     this.attributeDataConfig.next(dataConfig);
   }
 }

--- a/projects/viz-components/src/lib/map-chart/map-content.ts
+++ b/projects/viz-components/src/lib/map-chart/map-content.ts
@@ -1,6 +1,6 @@
 import { Directive } from '@angular/core';
 import { combineLatest, takeUntil } from 'rxjs';
-import { AttributeDataDimensionConfig } from '../geographies/geographies.config';
+import { VicAttributeDataDimensionConfig } from '../geographies/geographies.config';
 import { Unsubscribe } from '../shared/unsubscribe.class';
 import { MapChartComponent } from './map-chart.component';
 
@@ -10,7 +10,7 @@ import { MapChartComponent } from './map-chart.component';
 @Directive()
 export abstract class MapContent extends Unsubscribe {
   attributeDataScale: any;
-  attributeDataConfig: AttributeDataDimensionConfig;
+  attributeDataConfig: VicAttributeDataDimensionConfig;
 
   constructor(public chart: MapChartComponent) {
     super();
@@ -31,6 +31,6 @@ export abstract class MapContent extends Unsubscribe {
 
   abstract setScaleAndConfig(
     scale: any,
-    config: AttributeDataDimensionConfig
+    config: VicAttributeDataDimensionConfig
   ): void;
 }

--- a/projects/viz-components/src/lib/map-legend/discontinuous-legend/discontinuous-legend.component.spec.ts
+++ b/projects/viz-components/src/lib/map-legend/discontinuous-legend/discontinuous-legend.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CategoricalAttributeDataDimensionConfig } from '../../geographies/geographies.config';
+import { VicCategoricalAttributeDataDimensionConfig } from '../../geographies/geographies.config';
 import { DiscontinuousLegendComponent } from './discontinuous-legend.component';
 
 describe('DiscontinuousLegendComponent', () => {
@@ -45,7 +45,7 @@ describe('DiscontinuousLegendComponent', () => {
 
   describe('setCategoricalValues', () => {
     beforeEach(() => {
-      component.config = new CategoricalAttributeDataDimensionConfig();
+      component.config = new VicCategoricalAttributeDataDimensionConfig();
       component.config.domain = ['a', 'b'];
       component.config.range = ['red', 'blue'];
       component.setCategoricalValues();

--- a/projects/viz-components/src/lib/map-legend/map-legend-content.spec.ts
+++ b/projects/viz-components/src/lib/map-legend/map-legend-content.spec.ts
@@ -1,6 +1,6 @@
 import {
-  CategoricalAttributeDataDimensionConfig,
-  EqualValuesQuantitativeAttributeDataDimensionConfig,
+  VicCategoricalAttributeDataDimensionConfig,
+  VicEqualValuesQuantitativeAttributeDataDimensionConfig,
 } from '../geographies/geographies.config';
 import { MapLegendContentStub } from '../testing/stubs/map-legend-content.stub';
 
@@ -18,7 +18,7 @@ describe('the MapLegendContent abstract class', () => {
       spyOn(directive, 'getFormattedValues').and.returnValue(['1%', '2%']);
       directive.orientation = 'horizontal';
       directive.config =
-        new EqualValuesQuantitativeAttributeDataDimensionConfig();
+        new VicEqualValuesQuantitativeAttributeDataDimensionConfig();
       directive.config.valueFormat = 'test formatter';
     });
 
@@ -57,7 +57,7 @@ describe('the MapLegendContent abstract class', () => {
 
   describe('setColors', () => {
     beforeEach(() => {
-      directive.config = new CategoricalAttributeDataDimensionConfig();
+      directive.config = new VicCategoricalAttributeDataDimensionConfig();
       directive.config.domain = ['a', 'b'];
       directive.config.range = ['red', 'blue'];
     });

--- a/projects/viz-components/src/lib/map-legend/map-legend-content.ts
+++ b/projects/viz-components/src/lib/map-legend/map-legend-content.ts
@@ -1,5 +1,5 @@
 import { Directive, Input } from '@angular/core';
-import { AttributeDataDimensionConfig } from '../geographies/geographies.config';
+import { VicAttributeDataDimensionConfig } from '../geographies/geographies.config';
 import { formatValue } from '../value-format/value-format';
 
 @Directive()
@@ -9,7 +9,7 @@ export abstract class MapLegendContent {
   @Input() orientation: 'horizontal' | 'vertical';
   @Input() valuesSide: 'left' | 'right' | 'top' | 'bottom';
   @Input() scale: any;
-  @Input() config: AttributeDataDimensionConfig;
+  @Input() config: VicAttributeDataDimensionConfig;
   @Input() outlineColor: string;
   values: any[];
   colors: string[];

--- a/projects/viz-components/src/lib/map-legend/map-legend.component.ts
+++ b/projects/viz-components/src/lib/map-legend/map-legend.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
-import { AttributeDataDimensionConfig } from '../geographies/geographies.config';
+import { VicAttributeDataDimensionConfig } from '../geographies/geographies.config';
 import { MapChartComponent } from '../map-chart/map-chart.component';
 import { MapContent } from '../map-chart/map-content';
 
@@ -56,7 +56,7 @@ export class MapLegendComponent extends MapContent implements OnInit {
     }
   }
 
-  setScaleAndConfig(scale: any, config: AttributeDataDimensionConfig): void {
+  setScaleAndConfig(scale: any, config: VicAttributeDataDimensionConfig): void {
     if (scale && config) {
       this.attributeDataScale = scale;
       this.attributeDataConfig = config;

--- a/projects/viz-components/src/lib/shared/pattern-utilities.class.spec.ts
+++ b/projects/viz-components/src/lib/shared/pattern-utilities.class.spec.ts
@@ -1,9 +1,9 @@
-import { PatternPredicate } from '../data-marks/data-marks.config';
+import { VicPatternPredicate } from '../data-marks/data-marks.config';
 import { PatternUtilities } from './pattern-utilities.class';
 
 describe('PatternUtilities', () => {
   describe('integration: getPatternFill', () => {
-    const predicates: PatternPredicate[] = [
+    const predicates: VicPatternPredicate[] = [
       { patternName: 'pattern', predicate: (d: number) => d > 2 },
     ];
     it('returns pattern when predicate is true', () => {

--- a/projects/viz-components/src/lib/shared/pattern-utilities.class.ts
+++ b/projects/viz-components/src/lib/shared/pattern-utilities.class.ts
@@ -1,4 +1,4 @@
-import { PatternPredicate } from '../data-marks/data-marks.config';
+import { VicPatternPredicate } from '../data-marks/data-marks.config';
 
 /**
  * @internal
@@ -7,10 +7,10 @@ export class PatternUtilities {
   static getPatternFill(
     datum: any,
     defaultColor: string,
-    predicates: PatternPredicate[]
+    predicates: VicPatternPredicate[]
   ) {
     if (predicates) {
-      predicates.forEach((predMapping: PatternPredicate) => {
+      predicates.forEach((predMapping: VicPatternPredicate) => {
         if (predMapping.predicate(datum)) {
           defaultColor = `url(#${predMapping.patternName})`;
         }

--- a/projects/viz-components/src/lib/stacked-area/stacked-area-hover-move.directive.ts
+++ b/projects/viz-components/src/lib/stacked-area/stacked-area-hover-move.directive.ts
@@ -7,7 +7,7 @@ import { HoverMoveEventEffect } from '../events/effect';
 import { HoverMoveDirective } from '../events/hover-move.directive';
 import {
   getStackedAreaTooltipData,
-  StackedAreaEventOutput,
+  VicStackedAreaEventOutput,
 } from './stacked-area-tooltip-data';
 import { StackedAreaComponent, STACKED_AREA } from './stacked-area.component';
 
@@ -18,7 +18,7 @@ export class StackedAreaHoverMoveDirective extends HoverMoveDirective {
   @Input('vicStackedAreaHoverMoveEffects')
   effects: HoverMoveEventEffect<StackedAreaHoverMoveDirective>[];
   @Output('vicStackedAreaHoverMoveOutput') eventOutput =
-    new EventEmitter<StackedAreaEventOutput>();
+    new EventEmitter<VicStackedAreaEventOutput>();
   pointerX: number;
   pointerY: number;
   closestXIndicies: number[];
@@ -97,7 +97,7 @@ export class StackedAreaHoverMoveDirective extends HoverMoveDirective {
     }
   }
 
-  getTooltipData(): StackedAreaEventOutput {
+  getTooltipData(): VicStackedAreaEventOutput {
     const tooltipData = getStackedAreaTooltipData(
       this.closestXIndicies,
       this.stackedArea

--- a/projects/viz-components/src/lib/stacked-area/stacked-area-tooltip-data.ts
+++ b/projects/viz-components/src/lib/stacked-area/stacked-area-tooltip-data.ts
@@ -1,13 +1,13 @@
 import { formatValue } from '../value-format/value-format';
 import { StackedAreaComponent } from './stacked-area.component';
 
-export interface StackedAreaEventOutput {
-  data: StackedAreaEventDatum[];
+export interface VicStackedAreaEventOutput {
+  data: VicStackedAreaEventDatum[];
   positionX: number;
   svgHeight?: number;
 }
 
-export interface StackedAreaEventDatum {
+export interface VicStackedAreaEventDatum {
   datum: any[];
   color: string;
   x: string;
@@ -18,7 +18,7 @@ export interface StackedAreaEventDatum {
 export function getStackedAreaTooltipData(
   closestXIndicies: number[],
   stackedArea: StackedAreaComponent
-): StackedAreaEventOutput {
+): VicStackedAreaEventOutput {
   const data = closestXIndicies.map((i) => {
     const originalDatum = stackedArea.config.data.find(
       (d) =>

--- a/projects/viz-components/src/lib/stacked-area/stacked-area.component.spec.ts
+++ b/projects/viz-components/src/lib/stacked-area/stacked-area.component.spec.ts
@@ -5,7 +5,7 @@ import { MainServiceStub } from '../testing/stubs/services/main.service.stub';
 import { XyChartComponent } from '../xy-chart/xy-chart.component';
 
 import { StackedAreaComponent } from './stacked-area.component';
-import { StackedAreaConfig } from './stacked-area.config';
+import { VicStackedAreaConfig } from './stacked-area.config';
 
 describe('StackedAreaComponent', () => {
   let component: StackedAreaComponent;
@@ -29,7 +29,7 @@ describe('StackedAreaComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(StackedAreaComponent);
     component = fixture.componentInstance;
-    component.config = new StackedAreaConfig();
+    component.config = new VicStackedAreaConfig();
   });
 
   describe('ngOnChanges()', () => {

--- a/projects/viz-components/src/lib/stacked-area/stacked-area.component.ts
+++ b/projects/viz-components/src/lib/stacked-area/stacked-area.component.ts
@@ -27,7 +27,7 @@ import { UtilitiesService } from '../core/services/utilities.service';
 import { DATA_MARKS } from '../data-marks/data-marks.token';
 import { XyDataMarks, XyDataMarksValues } from '../data-marks/xy-data-marks';
 import { XyContent } from '../xy-chart/xy-content';
-import { StackedAreaConfig } from './stacked-area.config';
+import { VicStackedAreaConfig } from './stacked-area.config';
 
 export const STACKED_AREA = new InjectionToken<StackedAreaComponent>(
   'StackedAreaComponent'
@@ -48,7 +48,7 @@ export class StackedAreaComponent
   extends XyContent
   implements XyDataMarks, OnChanges, OnInit
 {
-  @Input() config: StackedAreaConfig;
+  @Input() config: VicStackedAreaConfig;
   values: XyDataMarksValues = new XyDataMarksValues();
   series: (SeriesPoint<InternMap<any, number>> & { i: number })[][];
   area;

--- a/projects/viz-components/src/lib/stacked-area/stacked-area.config.ts
+++ b/projects/viz-components/src/lib/stacked-area/stacked-area.config.ts
@@ -8,16 +8,16 @@ import {
   stackOrderNone,
 } from 'd3';
 import {
-  CategoricalColorDimensionConfig,
-  QuantitativeDimensionConfig,
+  VicCategoricalColorDimensionConfig,
+  VicQuantitativeDimensionConfig,
 } from '../data-marks/data-dimension.config';
-import { DataMarksConfig } from '../data-marks/data-marks.config';
+import { VicDataMarksConfig } from '../data-marks/data-marks.config';
 
-export class StackedAreaConfig extends DataMarksConfig {
-  x: QuantitativeDimensionConfig = new QuantitativeDimensionConfig();
-  y: QuantitativeDimensionConfig = new QuantitativeDimensionConfig();
-  category: CategoricalColorDimensionConfig =
-    new CategoricalColorDimensionConfig();
+export class VicStackedAreaConfig extends VicDataMarksConfig {
+  x: VicQuantitativeDimensionConfig = new VicQuantitativeDimensionConfig();
+  y: VicQuantitativeDimensionConfig = new VicQuantitativeDimensionConfig();
+  category: VicCategoricalColorDimensionConfig =
+    new VicCategoricalColorDimensionConfig();
   valueIsDefined?: (...args: any) => any;
   curve: (x: any) => any;
   stackOffsetFunction: (
@@ -27,7 +27,7 @@ export class StackedAreaConfig extends DataMarksConfig {
   stackOrderFunction: (x: any) => any;
   categoryOrder?: string[];
 
-  constructor(init?: Partial<StackedAreaConfig>) {
+  constructor(init?: Partial<VicStackedAreaConfig>) {
     super();
     this.x.valueAccessor = ([x]) => x;
     this.x.scaleType = scaleUtc;

--- a/projects/viz-components/src/lib/stacked-bars/stacked-bars.component.ts
+++ b/projects/viz-components/src/lib/stacked-bars/stacked-bars.component.ts
@@ -16,7 +16,7 @@ import {
 } from 'd3';
 import { BarsComponent } from '../bars/bars.component';
 import { DATA_MARKS } from '../data-marks/data-marks.token';
-import { StackDatum, StackedBarsConfig } from './stacked-bars.config';
+import { VicStackDatum, VicStackedBarsConfig } from './stacked-bars.config';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -28,7 +28,7 @@ import { StackDatum, StackedBarsConfig } from './stacked-bars.config';
   providers: [{ provide: DATA_MARKS, useExisting: StackedBarsComponent }],
 })
 export class StackedBarsComponent extends BarsComponent {
-  @Input() override config: StackedBarsConfig;
+  @Input() override config: VicStackedBarsConfig;
   stackedData: any;
 
   override setMethodsFromConfigAndDraw(): void {
@@ -108,19 +108,23 @@ export class StackedBarsComponent extends BarsComponent {
         (enter) =>
           enter
             .append('rect')
-            .attr('x', (i) => this.getStackElementX(i as StackDatum))
-            .attr('y', (i) => this.getStackElementY(i as StackDatum))
-            .attr('width', (i) => this.getStackElementWidth(i as StackDatum))
-            .attr('height', (i) => this.getStackElementHeight(i as StackDatum)),
+            .attr('x', (i) => this.getStackElementX(i as VicStackDatum))
+            .attr('y', (i) => this.getStackElementY(i as VicStackDatum))
+            .attr('width', (i) => this.getStackElementWidth(i as VicStackDatum))
+            .attr('height', (i) =>
+              this.getStackElementHeight(i as VicStackDatum)
+            ),
         (update) =>
           update.call((update) =>
             update
               .transition(t as any)
-              .attr('x', (i) => this.getStackElementX(i as StackDatum))
-              .attr('y', (i) => this.getStackElementY(i as StackDatum))
-              .attr('width', (i) => this.getStackElementWidth(i as StackDatum))
+              .attr('x', (i) => this.getStackElementX(i as VicStackDatum))
+              .attr('y', (i) => this.getStackElementY(i as VicStackDatum))
+              .attr('width', (i) =>
+                this.getStackElementWidth(i as VicStackDatum)
+              )
               .attr('height', (i) =>
-                this.getStackElementHeight(i as StackDatum)
+                this.getStackElementHeight(i as VicStackDatum)
               )
           ),
         (exit) =>
@@ -133,7 +137,7 @@ export class StackedBarsComponent extends BarsComponent {
       );
   }
 
-  getStackElementX(datum: StackDatum): number {
+  getStackElementX(datum: VicStackDatum): number {
     // no unit test
     if (this.config.dimensions.ordinal === 'x') {
       return this.xScale(this.values.x[datum.i]);
@@ -142,7 +146,7 @@ export class StackedBarsComponent extends BarsComponent {
     }
   }
 
-  getStackElementY(datum: StackDatum): number {
+  getStackElementY(datum: VicStackDatum): number {
     // no unit test
     if (this.config.dimensions.ordinal === 'x') {
       return Math.min(this.yScale(datum[0]), this.yScale(datum[1]));
@@ -151,7 +155,7 @@ export class StackedBarsComponent extends BarsComponent {
     }
   }
 
-  getStackElementWidth(datum: StackDatum): number {
+  getStackElementWidth(datum: VicStackDatum): number {
     // no unit test
     if (this.config.dimensions.ordinal === 'x') {
       return (this.xScale as any).bandwidth();
@@ -160,7 +164,7 @@ export class StackedBarsComponent extends BarsComponent {
     }
   }
 
-  getStackElementHeight(datum: StackDatum): number {
+  getStackElementHeight(datum: VicStackDatum): number {
     // no unit test
     if (this.config.dimensions.ordinal === 'x') {
       return Math.abs(this.yScale(datum[0]) - this.yScale(datum[1]));

--- a/projects/viz-components/src/lib/stacked-bars/stacked-bars.config.ts
+++ b/projects/viz-components/src/lib/stacked-bars/stacked-bars.config.ts
@@ -1,11 +1,11 @@
 import { InternMap, stackOffsetDiverging, stackOrderNone } from 'd3';
-import { BarsConfig } from '../bars/bars.config';
+import { VicBarsConfig } from '../bars/bars.config';
 
-export class StackedBarsConfig extends BarsConfig {
+export class VicStackedBarsConfig extends VicBarsConfig {
   order: any;
   offset: any;
 
-  constructor(init?: Partial<StackedBarsConfig>) {
+  constructor(init?: Partial<VicStackedBarsConfig>) {
     super();
     this.order = stackOrderNone;
     this.offset = stackOffsetDiverging;
@@ -13,12 +13,14 @@ export class StackedBarsConfig extends BarsConfig {
   }
 }
 
-export interface StackDatumData {
+export interface VicStackDatumData {
   data: [string, InternMap];
 }
 
-export interface StackDatumIndex {
+export interface VicStackDatumIndex {
   i: number;
 }
 
-export type StackDatum = [number, number] & StackDatumData & StackDatumIndex;
+export type VicStackDatum = [number, number] &
+  VicStackDatumData &
+  VicStackDatumIndex;

--- a/projects/viz-components/src/lib/svg-text-wrap/svg-text-wrap.ts
+++ b/projects/viz-components/src/lib/svg-text-wrap/svg-text-wrap.ts
@@ -1,7 +1,7 @@
 import { select } from 'd3';
-import { SvgTextWrapConfig } from './svg-wrap.config';
+import { VicSvgTextWrapConfig } from './svg-wrap.config';
 
-export function svgTextWrap(textSelection, options: SvgTextWrapConfig) {
+export function svgTextWrap(textSelection, options: VicSvgTextWrapConfig) {
   const { width, maintainXPosition, maintainYPosition, lineHeight } = options;
 
   textSelection.each((d, i, nodes) => {

--- a/projects/viz-components/src/lib/svg-text-wrap/svg-wrap.config.ts
+++ b/projects/viz-components/src/lib/svg-text-wrap/svg-wrap.config.ts
@@ -1,16 +1,11 @@
-export class SvgTextWrapConfig {
-  // test comment
+export class VicSvgTextWrapConfig {
   width: number;
   maintainXPosition: boolean;
   maintainYPosition: boolean;
-  /**
-   * multiline test comment
-   */
   lineHeight: number;
 
-  constructor(init?: Partial<SvgTextWrapConfig>) {
+  constructor(init?: Partial<VicSvgTextWrapConfig>) {
     this.maintainXPosition = false;
-    // another test comment
     this.maintainYPosition = false;
     this.lineHeight = 1.1;
     Object.assign(this, init);

--- a/projects/viz-components/src/lib/svg-text-wrap/tick-wrap.config.ts
+++ b/projects/viz-components/src/lib/svg-text-wrap/tick-wrap.config.ts
@@ -1,9 +1,9 @@
-import { SvgTextWrapConfig } from './svg-wrap.config';
+import { VicSvgTextWrapConfig as VicSvgTextWrapConfig } from './svg-wrap.config';
 
 /**
  * A config that specifies how axis tick labels should wrap.
  */
-export class TickWrapConfig extends SvgTextWrapConfig {
+export class VicTickWrapConfig extends VicSvgTextWrapConfig {
   /**
    * The max-width for the tick labels.
    *
@@ -21,7 +21,7 @@ export class TickWrapConfig extends SvgTextWrapConfig {
     | ((chartWidth: number, numOfTicks: number) => number);
   override width: never;
 
-  constructor(init?: Partial<TickWrapConfig>) {
+  constructor(init?: Partial<VicTickWrapConfig>) {
     super();
     Object.assign(this, init);
   }

--- a/projects/viz-components/src/lib/testing/stubs/map-content.stub.ts
+++ b/projects/viz-components/src/lib/testing/stubs/map-content.stub.ts
@@ -1,8 +1,8 @@
-import { AttributeDataDimensionConfig } from '../../geographies/geographies.config';
+import { VicAttributeDataDimensionConfig } from '../../geographies/geographies.config';
 import { MapContent } from '../../map-chart/map-content';
 
 export class MapContentStub extends MapContent {
-  setScaleAndConfig(scale: any, config: AttributeDataDimensionConfig): void {
+  setScaleAndConfig(scale: any, config: VicAttributeDataDimensionConfig): void {
     return;
   }
 }

--- a/projects/viz-components/src/lib/testing/stubs/map-legend.component.stub.ts
+++ b/projects/viz-components/src/lib/testing/stubs/map-legend.component.stub.ts
@@ -1,7 +1,7 @@
-import { CategoricalAttributeDataDimensionConfig } from '../../geographies/geographies.config';
+import { VicCategoricalAttributeDataDimensionConfig } from '../../geographies/geographies.config';
 
 export class MapLegendComponentStub {
-  attributeDataConfig = new CategoricalAttributeDataDimensionConfig();
+  attributeDataConfig = new VicCategoricalAttributeDataDimensionConfig();
 
   constructor() {
     this.attributeDataConfig.range = ['red', 'blue'];

--- a/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.config.ts
+++ b/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.config.ts
@@ -1,12 +1,12 @@
 import { ConnectedPosition, OverlaySizeConfig } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
-import { TooltipConfig } from '../tooltip.config';
+import { VicTooltipConfig } from '../tooltip.config';
 
-export class HtmlTooltipConfig extends TooltipConfig {
+export class VicHtmlTooltipConfig extends VicTooltipConfig {
   override type: 'html';
   position:
-    | HtmlTooltipCdkManagedFromOriginPosition
-    | HtmlTooltipOffsetFromOriginPosition;
+    | VicHtmlTooltipCdkManagedFromOriginPosition
+    | VicHtmlTooltipOffsetFromOriginPosition;
   size: OverlaySizeConfig;
   addEventsDisabledClass: boolean;
   panelClass: string | string[];
@@ -14,16 +14,16 @@ export class HtmlTooltipConfig extends TooltipConfig {
   hasBackdrop: boolean;
   closeOnBackdropClick?: boolean;
 
-  constructor(init?: Partial<HtmlTooltipConfig>) {
+  constructor(init?: Partial<VicHtmlTooltipConfig>) {
     super();
-    this.size = new HtmlTooltipSize();
+    this.size = new VicHtmlTooltipSize();
     this.hasBackdrop = false;
     this.closeOnBackdropClick = false;
     Object.assign(this, init);
   }
 }
 
-export class HtmlTooltipOffsetFromOriginPosition {
+export class VicHtmlTooltipOffsetFromOriginPosition {
   type: 'global';
   offsetY: number;
   offsetX: number;
@@ -40,18 +40,18 @@ export class HtmlTooltipOffsetFromOriginPosition {
   }
 }
 
-export class HtmlTooltipCdkManagedFromOriginPosition {
+export class VicHtmlTooltipCdkManagedFromOriginPosition {
   type: 'connected';
   config: ConnectedPosition;
 
   constructor() {
     this.type = 'connected';
-    this.config = new HtmlTooltipDefaultConnectedPosition();
+    this.config = new VicHtmlTooltipDefaultConnectedPosition();
   }
 }
 
 /** Default position for the overlay. Follows the behavior of a tooltip. */
-export class HtmlTooltipDefaultConnectedPosition {
+export class VicHtmlTooltipDefaultConnectedPosition {
   originX: 'start' | 'center' | 'end';
   originY: 'top' | 'center' | 'bottom';
   overlayX: 'start' | 'center' | 'end';
@@ -70,4 +70,4 @@ export class HtmlTooltipDefaultConnectedPosition {
   }
 }
 
-export class HtmlTooltipSize implements OverlaySizeConfig {}
+export class VicHtmlTooltipSize implements OverlaySizeConfig {}

--- a/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.directive.spec.ts
+++ b/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.directive.spec.ts
@@ -7,7 +7,7 @@ import { UtilitiesService } from '../../core/services/utilities.service';
 import { DataMarks } from '../../data-marks/data-marks';
 import { DATA_MARKS } from '../../data-marks/data-marks.token';
 import { MainServiceStub } from '../../testing/stubs/services/main.service.stub';
-import { HtmlTooltipConfig } from './html-tooltip.config';
+import { VicHtmlTooltipConfig } from './html-tooltip.config';
 import { HtmlTooltipDirective } from './html-tooltip.directive';
 
 describe('HtmlTooltipDirective', () => {
@@ -80,7 +80,7 @@ describe('HtmlTooltipDirective', () => {
       spyOn(directive, 'checkBackdropChanges');
       spyOn(directive, 'updateVisibility');
       spyOn(directive, 'init');
-      directive.config = new HtmlTooltipConfig();
+      directive.config = new VicHtmlTooltipConfig();
       changes = {};
     });
     describe('if overlayRef and config are truthy', () => {
@@ -487,7 +487,7 @@ describe('HtmlTooltipDirective', () => {
   describe('setPanelClasses', () => {
     describe('if addEventsDisabledClass is false', () => {
       beforeEach(() => {
-        directive.config = new HtmlTooltipConfig();
+        directive.config = new VicHtmlTooltipConfig();
         directive.config.addEventsDisabledClass = false;
       });
       it('sets panel class to the correct value - case user provides single string', () => {
@@ -514,7 +514,7 @@ describe('HtmlTooltipDirective', () => {
     });
     describe('if addEventsDisabledClass is true', () => {
       beforeEach(() => {
-        directive.config = new HtmlTooltipConfig();
+        directive.config = new VicHtmlTooltipConfig();
         directive.config.addEventsDisabledClass = true;
       });
       it('sets panel class to the correct value - case user provides single string', () => {

--- a/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.directive.ts
+++ b/projects/viz-components/src/lib/tooltips/html-tooltip/html-tooltip.directive.ts
@@ -27,9 +27,9 @@ import { UtilitiesService } from '../../core/services/utilities.service';
 import { DataMarks } from '../../data-marks/data-marks';
 import { DATA_MARKS } from '../../data-marks/data-marks.token';
 import {
-  HtmlTooltipCdkManagedFromOriginPosition,
-  HtmlTooltipConfig,
-  HtmlTooltipOffsetFromOriginPosition,
+  VicHtmlTooltipCdkManagedFromOriginPosition,
+  VicHtmlTooltipConfig,
+  VicHtmlTooltipOffsetFromOriginPosition,
 } from './html-tooltip.config';
 
 const defaultPanelClass = 'vic-html-tooltip-overlay';
@@ -40,7 +40,7 @@ const defaultPanelClass = 'vic-html-tooltip-overlay';
 })
 export class HtmlTooltipDirective implements OnInit, OnChanges, OnDestroy {
   @Input() template: TemplateRef<unknown>;
-  @Input() config: HtmlTooltipConfig;
+  @Input() config: VicHtmlTooltipConfig;
   @Output() backdropClick = new EventEmitter<void>();
   overlayRef: OverlayRef;
   positionStrategy: FlexibleConnectedPositionStrategy | GlobalPositionStrategy;
@@ -87,7 +87,7 @@ export class HtmlTooltipDirective implements OnInit, OnChanges, OnDestroy {
 
   configChanged(
     changes: SimpleChanges,
-    property: keyof HtmlTooltipConfig
+    property: keyof VicHtmlTooltipConfig
   ): boolean {
     return this.utilities.objectOnNgChangesChanged(changes, 'config', property);
   }
@@ -223,7 +223,7 @@ export class HtmlTooltipDirective implements OnInit, OnChanges, OnDestroy {
 
   setConnectedPositionStrategy(
     origin: Element,
-    position: HtmlTooltipCdkManagedFromOriginPosition
+    position: VicHtmlTooltipCdkManagedFromOriginPosition
   ): void {
     this.positionStrategy = this.overlayPositionBuilder
       .flexibleConnectedTo(origin)
@@ -232,7 +232,7 @@ export class HtmlTooltipDirective implements OnInit, OnChanges, OnDestroy {
 
   setGlobalPositionStrategy(
     origin: Element,
-    position: HtmlTooltipOffsetFromOriginPosition
+    position: VicHtmlTooltipOffsetFromOriginPosition
   ): void {
     // gets dims without scrollbar thickness if scrollbar is on html or body
     const _window = this._document.defaultView || window;

--- a/projects/viz-components/src/lib/tooltips/svg-tooltip/svg-tooltip.config.ts
+++ b/projects/viz-components/src/lib/tooltips/svg-tooltip/svg-tooltip.config.ts
@@ -1,5 +1,5 @@
-import { TooltipConfig } from '../tooltip.config';
+import { VicTooltipConfig } from '../tooltip.config';
 
-export class SvgTooltipConfig extends TooltipConfig {
+export class VicSvgTooltipConfig extends VicTooltipConfig {
   override type: 'svg';
 }

--- a/projects/viz-components/src/lib/tooltips/tooltip.config.ts
+++ b/projects/viz-components/src/lib/tooltips/tooltip.config.ts
@@ -1,8 +1,8 @@
-export class TooltipConfig {
+export class VicTooltipConfig {
   show: boolean;
   type: 'svg' | 'html';
 
-  constructor(init?: Partial<TooltipConfig>) {
+  constructor(init?: Partial<VicTooltipConfig>) {
     this.show = false;
     Object.assign(this, init);
   }

--- a/projects/viz-components/src/lib/value-format/value-format.ts
+++ b/projects/viz-components/src/lib/value-format/value-format.ts
@@ -1,8 +1,8 @@
 import { format, timeFormat } from 'd3';
 
-export type FormatSpecifier = string | ((x: unknown) => string);
+export type VicFormatSpecifier = string | ((x: unknown) => string);
 
-export interface ValueFormats {
+export interface VicValueFormats {
   integer: string;
   integerNoComma: string;
   percent: (digits: number) => string;
@@ -13,7 +13,7 @@ export interface ValueFormats {
   monthFullYear: string;
 }
 
-export const valueFormat: ValueFormats = {
+export const valueFormat: VicValueFormats = {
   integer: ',.0f',
   integerNoComma: '.0f',
   percent: (digits: number) => `.${digits}%`,
@@ -26,7 +26,7 @@ export const valueFormat: ValueFormats = {
 
 export function formatValue(
   value: any,
-  formatSpecifier: FormatSpecifier
+  formatSpecifier: VicFormatSpecifier
 ): string {
   if (formatSpecifier && typeof formatSpecifier === 'function') {
     return formatSpecifier(value);

--- a/projects/viz-components/src/public-api.ts
+++ b/projects/viz-components/src/public-api.ts
@@ -21,6 +21,7 @@ export * from './lib/bars/bars-hover.directive';
 export * from './lib/bars/bars-input-event.directive';
 export * from './lib/bars/bars-click.directive';
 export * from './lib/bars/bars-click-effects';
+export * from './lib/bars/bars-tooltip-data';
 export * from './lib/bars/bars.component';
 export * from './lib/bars/bars.config';
 export * from './lib/bars/bars.module';


### PR DESCRIPTION
Renamed relevant items in every `.config` file and every `-tooltip-data` file. Also `value-format.ts`. Closes #170. 