### PR TITLE
modify rxjs version for ui components

### DIFF
--- a/projects/ui-components/package.json
+++ b/projects/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsi/ui-components",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "peerDependencies": {
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",


### PR DESCRIPTION
Aaron reported that there was no conflict for viz-components, so matching the versions there. 

Error reported by Aaron: 
![image](https://github.com/user-attachments/assets/53328667-6aa6-41bb-ac61-e888b011f31f)
