### PR TITLE
Three line wrap bug

### DIFF
--- a/libs/viz-components/src/lib/svg-text-wrap/svg-text-wrap.ts
+++ b/libs/viz-components/src/lib/svg-text-wrap/svg-text-wrap.ts
@@ -47,13 +47,9 @@ export class SvgTextWrap {
           tspan = text
             .append('tspan')
             .attr('x', x)
-            .attr(
-              'dy',
-              (lineNumber === 0 ? ++lineNumber : lineNumber) * this.lineHeight +
-                dy +
-                'em'
-            )
+            .attr('dy', this.lineHeight + dy + 'em')
             .text(word);
+          ++lineNumber;
         }
       }
       if (this.maintainYPosition && lineNumber > 0) {


### PR DESCRIPTION
Fix for bug that causes a larger gap when wrapping an axis label to be more than two lines (https://github.com/mathematica-org/frontend-shared-packages/issues/711)
<img width="1065" height="662" alt="image" src="https://github.com/user-attachments/assets/3076520b-547f-409e-a7be-876470f77c36" />


The fix can be seen working in https://github.com/mathematica-org/MACScorecard-Frontend/pull/1450/files which is running on a beta release with this fix.
