### PR TITLE
Grouped Combobox Bug

### DIFF
--- a/libs/ui-components/src/lib/combobox/listbox/listbox.component.ts
+++ b/libs/ui-components/src/lib/combobox/listbox/listbox.component.ts
@@ -95,6 +95,10 @@ export class ListboxComponent
   ngAfterContentInit(): void {
     this.service.setProjectedContent(this.groups, this.options);
     this.options
+      .toArray()
+      .concat(
+        this.groups.toArray().flatMap((group) => group.options?.toArray() ?? [])
+      )
       .filter((option) => option instanceof SelectAllListboxOptionComponent)
       .forEach((option) => {
         option.setControlledOptions();


### PR DESCRIPTION
ui-components v1.2.6 ([Fix Select All timing issues in UI components library](https://github.com/mathematica-org/frontend-shared-packages/pull/709)) accidentally introduced a bug which makes it so that select all does not work in grouped comboboxes. This is a quick bugfix to fix that