### PR TITLE
GitHub page publish

### DIFF
--- a/.github/workflows/deploy-demo-page.yml
+++ b/.github/workflows/deploy-demo-page.yml
@@ -3,7 +3,7 @@ name: deploy demo-app to github pages
 on:
   push:
     branches:
-      - github-page-publish
+      - main
 
   workflow_dispatch:
 


### PR DESCRIPTION
TODO before merge: 
- update branches to "main"
- Remove github-page-publish from allowed branches in pages settings